### PR TITLE
Change mkdocs template to material

### DIFF
--- a/docs/ADRs/0001-adrs.md
+++ b/docs/ADRs/0001-adrs.md
@@ -1,10 +1,12 @@
 ---
-title: 0001 ADRs
-adr:
-  author: Anne Schuth
-  created: 16-Feb-2024
-  status: accepted
+    title: ADR-0001 ADRs
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Anne Schuth |
+| Created | 16-Feb-2024     |
+| Status  | Accepted         |
 
 ## Context
 
@@ -30,16 +32,17 @@ Use the template below to add an ADR:
 
 ```yaml
 ---
-    title: 0004 Title
-    adr:
-        author: Jean-Loup Monnier
-        created: 01-Aug-2023
-        status:  draft | proposed | rejected | accepted | superseded
-        superseded_by: 0001-test
-        extends:
-            - 0001-first
-            - 0002-second
+    title: ADR-4 Title
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Anne Schuth |
+| Created | 28-Feb-2024  |
+| Status  | Draft, Proposed, Rejected, Accepted, Superseded |
+| Superseded by | ADR-0001 |
+| extends | ADR-0001, ADR-0002 |
+
 
 ## Context
 

--- a/docs/ADRs/0002-code-platform.md
+++ b/docs/ADRs/0002-code-platform.md
@@ -1,10 +1,12 @@
 ---
-    title: 0002 Code Platform
-    adr:
-        author: Berry den Hartog
-        created: 28-Feb-2024
-        status:  accepted
+    title: ADR-0002 Code Platform
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Berry den Hartog |
+| Created | 28-Feb-2024      |
+| Status  | Accepted         |
 
 ## Context
 

--- a/docs/ADRs/0003-ci-cd.md
+++ b/docs/ADRs/0003-ci-cd.md
@@ -1,10 +1,12 @@
 ---
-    title: 0003 Continuous Integration/Continuous Deployment (CI/CD) Tooling
-    adr:
-        author: Berry den Hartog
-        created: 28-Feb-2024
-        status: accepted
+    title: ADR-0003 CI/CD Tooling
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Berry den Hartog |
+| Created | 28-Feb-2024      |
+| Status  | Accepted         |
 
 ## Context
 

--- a/docs/ADRs/0004-software-hosting-platform.md
+++ b/docs/ADRs/0004-software-hosting-platform.md
@@ -1,10 +1,12 @@
 ---
-    title: 0004 Software hosting platform
-    adr:
-        author: Berry den Hartog
-        created: 28-Feb-2024
-        status:  accepted
+    title: ADR-0004 Software hosting platform
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Berry den Hartog |
+| Created | 28-Feb-2024      |
+| Status  | Accepted         |
 
 ## Context
 

--- a/docs/ADRs/0005-python-tooling.md
+++ b/docs/ADRs/0005-python-tooling.md
@@ -1,10 +1,12 @@
 ---
-    title: 0005 Python coding standard and tools
-    adr:
-        author: Berry den Hartog
-        created: 28-Feb-2024
-        status:  accepted
+    title: ADR-0005 Python coding standard and tools
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Berry den Hartog |
+| Created | 28-Feb-2024      |
+| Status  | Accepted         |
 
 ## Context
 

--- a/docs/ADRs/0006-agile-tooling.md
+++ b/docs/ADRs/0006-agile-tooling.md
@@ -1,10 +1,12 @@
 ---
-    title: 0006 Agile tooling
-    adr:
-        author: Berry den Hartog
-        created: 28-Feb-2024
-        status:  accepted
+    title: ADR-0006 Agile tooling
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Berry den Hartog |
+| Created | 28-Feb-2024      |
+| Status  | Accepted         |
 
 ## Context
 

--- a/docs/ADRs/0007-commit-convention.md
+++ b/docs/ADRs/0007-commit-convention.md
@@ -1,10 +1,12 @@
 ---
-    title: 0007 Commit convention
-    adr:
-        author: Berry den Hartog
-        created: 28-Feb-2024
-        status:  accepted
+    title: ADR-0007 Commit convention
 ---
+
+|     |                  |
+| ---     | --- |
+| Author  | Berry den Hartog |
+| Created | 28-Feb-2024      |
+| Status  | Accepted         |
 
 ## Context
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: Documenting the processes of the AI Validation Team at the Min
 
 ### theme settings ###
 theme:
-    name: mkdocs-material-adr
+    name: material
     language: en
     palette:
         primary: deep orange
@@ -54,7 +54,6 @@ extra_css:
     - stylesheets/extra.css
 
 plugins:
-    - mkdocs-material-adr/adr
     - glightbox
     - git-revision-date-localized:
         enable_creation_date: true


### PR DESCRIPTION
# Description

I changed the mkdocs-material-adr template to material. This was needed because the additional plugins like `search` did not work. 

After investigation i could not figure out why the searchbox was not working. 
