### PR TITLE
Remove `mkdocs-material-adr` from project requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ mkdocs==1.5.3
 mkdocs-git-revision-date-localized-plugin==1.2.4
 mkdocs-glightbox==0.3.7
 mkdocs-material==9.5.12
-mkdocs-material-adr==1.1.0
 mkdocs-material-extensions==1.3.1
 pymdown-extensions==10.7


### PR DESCRIPTION
# Description

The mkdocs-material-adr plugin is removed from the project. Let's also remove it from the project requirements.
