### PR TITLE
Add plugin to show document contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 .venv
 build
 site
+.cache

--- a/docs/ADRs/0001-adrs.md
+++ b/docs/ADRs/0001-adrs.md
@@ -22,19 +22,8 @@ will publish these ADRs publicly to promote transparency and facilitate collabor
 
 Use the template below to add an ADR:
 
-```yaml
----
-    title: ADR-4 Title
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Anne Schuth |
-| Created | 28-Feb-2024  |
-| Status  | Draft, Proposed, Rejected, Accepted, Superseded |
-| Superseded by | ADR-0001 |
-| extends | ADR-0001, ADR-0002 |
-
+```markdown
+# ADR-XXXX Title
 
 ## Context
 

--- a/docs/ADRs/0001-adrs.md
+++ b/docs/ADRs/0001-adrs.md
@@ -1,12 +1,4 @@
----
-    title: ADR-0001 ADRs
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Anne Schuth |
-| Created | 16-Feb-2024     |
-| Status  | Accepted         |
+# ADR-0001 ADRs
 
 ## Context
 

--- a/docs/ADRs/0002-code-platform.md
+++ b/docs/ADRs/0002-code-platform.md
@@ -1,12 +1,4 @@
----
-    title: ADR-0002 Code Platform
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Berry den Hartog |
-| Created | 28-Feb-2024      |
-| Status  | Accepted         |
+# ADR-0002 Code Platform
 
 ## Context
 

--- a/docs/ADRs/0003-ci-cd.md
+++ b/docs/ADRs/0003-ci-cd.md
@@ -1,12 +1,4 @@
----
-    title: ADR-0003 CI/CD Tooling
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Berry den Hartog |
-| Created | 28-Feb-2024      |
-| Status  | Accepted         |
+# ADR-0003 CI/CD Tooling
 
 ## Context
 

--- a/docs/ADRs/0004-software-hosting-platform.md
+++ b/docs/ADRs/0004-software-hosting-platform.md
@@ -1,12 +1,4 @@
----
-    title: ADR-0004 Software hosting platform
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Berry den Hartog |
-| Created | 28-Feb-2024      |
-| Status  | Accepted         |
+# ADR-0004 Software hosting platform
 
 ## Context
 

--- a/docs/ADRs/0005-python-tooling.md
+++ b/docs/ADRs/0005-python-tooling.md
@@ -1,12 +1,4 @@
----
-    title: ADR-0005 Python coding standard and tools
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Berry den Hartog |
-| Created | 28-Feb-2024      |
-| Status  | Accepted         |
+# ADR-0005 Python coding standard and tools
 
 ## Context
 

--- a/docs/ADRs/0006-agile-tooling.md
+++ b/docs/ADRs/0006-agile-tooling.md
@@ -1,12 +1,5 @@
----
-    title: ADR-0006 Agile tooling
----
 
-|     |                  |
-| ---     | --- |
-| Author  | Berry den Hartog |
-| Created | 28-Feb-2024      |
-| Status  | Accepted         |
+# ADR-0006 Agile tooling
 
 ## Context
 

--- a/docs/ADRs/0007-commit-convention.md
+++ b/docs/ADRs/0007-commit-convention.md
@@ -1,12 +1,4 @@
----
-    title: ADR-0007 Commit convention
----
-
-|     |                  |
-| ---     | --- |
-| Author  | Berry den Hartog |
-| Created | 28-Feb-2024      |
-| Status  | Accepted         |
+# ADR-0007 Commit convention
 
 ## Context
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,10 +54,13 @@ extra_css:
     - stylesheets/extra.css
 
 plugins:
+    - search
     - glightbox
     - git-revision-date-localized:
         enable_creation_date: true
-    - search
+    - git-committers:
+        repository: minbzk/ai-validation
+        branch: main
 
 repo_url: https://github.com/MinBZK/ai-validation
 edit_uri: edit/main/docs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Jinja2>=2.11.1
 mkdocs==1.5.3
+mkdocs-git-committers-plugin-2==2.3.0
 mkdocs-git-revision-date-localized-plugin==1.2.4
 mkdocs-glightbox==0.3.7
 mkdocs-material==9.5.12


### PR DESCRIPTION
# Description

- Add a plugin to show document contributors.
- Remove author and created info from ADRs because similar information is present in the document's footer using the MkDocs plugins.

With the proposed change, we also lose the status info from the ADR. My suggestion is that we don't show this info in a table but that if we reject an ADR, we use admonitions on top of the page: https://squidfunk.github.io/mkdocs-material/reference/admonitions/