### PR TITLE
Add research for tad reporting standards

### DIFF
--- a/docs/Projects/TAD/reporting_standards.md
+++ b/docs/Projects/TAD/reporting_standards.md
@@ -2,24 +2,32 @@
 This document assesses standards that standardize the way algorithm assessments can be captured.
 
 ## Background
-There are many algorithm assessments (IAMA, HUIDERIA, etc.), technical tests on performance (Accuracy, TP, FP, F1, etc),
-fairness and bias of algorithms (SHAP) and reporting formats available. The goal is to have a way of standardizing the way these different
-assessments and tests can be captured. 
+There are many algorithm assessments (e.g. IAMA, HUIDERIA, etc.), technical tests on performance (e.g. Accuracy, TP, FP, F1, etc),
+fairness and bias of algorithms (e.g. SHAP) and reporting formats available. The goal is to have a way of standardizing the way these different
+assessments and tests can be captured.
 
 ## Available standards
 
 ### Model Cards
-The most interesting existing capturing method seems to be [Model Cards for Model Reporting](https://arxiv.org/pdf/1810.03993.pdf),
-which are "short documents accompanying trained machine learning models that provide benchmarked evaluation in a variety of conditions,
-such as across different cultural, demographic, or phenotypic groups (e.g., race, geographic location, sex, Fitzpatrick skin type) and
-intersectional groups (e.g., age and race, or sex and Fitzpatrick skin type) that are relevant to the intended application domains. Model
-cards also disclose the context in which models are intended to be used, details of the performance evaluation procedures, and other relevant information",
-proposed by Google.
+The most interesting existing capturing methods seem to be all based on [Model Cards for Model Reporting](https://arxiv.org/pdf/1810.03993.pdf),
+which are:
+>"Short documents accompanying trained machine learning models that provide benchmarked evaluation in a variety of conditions,
+>such as across different cultural, demographic, or phenotypic groups (e.g., race, geographic location, sex, Fitzpatrick skin type) and
+>intersectional groups (e.g., age and race, or sex and Fitzpatrick skin type) that are relevant to the intended application domains. Model
+>cards also disclose the context in which models are intended to be used, details of the performance evaluation procedures, and other relevant information",
+>proposed by Google. Note that "The proposed set of sections" in the Model Cards paper "are intended to provide relevant details to consider, but are not intended to be complete or
+>exhaustive, and may be tailored depending on the model, context, and stakeholders."
 
-An [implementation](https://huggingface.co/docs/hub/en/model-cards) of this paper exists on Hugging Face and is the standard way Hugging Face
-provides information on the models available on their platform. Their [experimental tool](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
-provides a UI to create a model card. Although the UI of this tool can certainly be improved, it might be the best starting point as a way 
-to standardize algorithm assessments. Also the tool allows for up- and dowloading assessments from and to markdown. 
+Many companies implement their own version of Model Cards, for example 
+[Meta System Cards](https://ai.meta.com/blog/system-cards-a-new-resource-for-understanding-how-ai-systems-work/) (with accompanying 
+[Research Paper](https://scontent-ams2-1.xx.fbcdn.net/v/t39.2365-6/277534097_2440637952739403_7120117370014241056_n.pdf?_nc_cat=110&ccb=1-7&_nc_sid=3c67a6&_nc_ohc=Aninj9n8dZkAX-taf6n&_nc_oc=AQljYgl-KvN8tKF_A8bcdgcBT_deV0wFzI06r_P7sZODn4m3T3YUJKVb1SWDGtdjOus&_nc_ht=scontent-ams2-1.xx&oh=00_AfAhz7YW2blPavGIzs-cOXyLMQnb-xjkc4nTuT4zKdif6w&oe=65F48231)) and the tools mentioned in the next section.
+
+#### Automatic model card generation
+There exist tools to (semi)-automatically generate models cards:
+1. [Model Card Generator by US Sensus Bureau](https://bias.xd.gov/resources/model-card-generator/). Basic UI to create model cards and export to markdown, also hase a command line tool.
+2. [Model Card Toolkit by Google](https://blog.research.google/2020/07/introducing-model-card-toolkit-for.html). Automation only comes from integration with [TensorFlowExtended](https://www.tensorflow.org/tfx) and [ML Metadata](https://www.tensorflow.org/tfx/guide/mlmd).
+3. [VerifyML](https://github.com/cylynx/verifyml?tab=readme-ov-file). Based on the Google toolkit, but is extended to include specific tests on fairness and bias. Technical tests can be added by users and model card schema (in protobuf) can be extended by users.
+4. [Experimental Model Cards Writing Tool by Hugging Face](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool). This is the implementation of the Google paper by Hugging Face and provides information on the models available on their platform. The writing tools guides users through their model card and allows for up- and downloading from and to markdown.
 
 ### Other standards
 [A landscape analysis of machine learning documentation tools](https://huggingface.co/docs/hub/en/model-card-landscape-analysis) has been
@@ -28,10 +36,13 @@ performed by Hugging Face and provides a good overview of the current landscape.
 Another interesting standard is the [Algorithmic Transparency Recording Standard (ATRS)](https://www.gov.uk/government/publications/algorithmic-transparency-template)
 of the United Kingdom Goverment. 
 
-
 ## Proposal
-Take the Hugging Face Model Cards as a base for our own standard. The Model Cards needs to be extended to be able to caputre 
-assessments like IAMA. The above mentioned experimental tool can be a good example of the functionalities that we would like
-to have in to process our standard, although the tool can certainly be improved for example by supporting de/serialization
-to different formats and by adjusting availbe evaluation, fairness and bias tests depending on the chosen model task.
+We need a standard that captures algorithmic assessments and technical tests on model and datasets. The idea of [model cards](https://arxiv.org/pdf/1810.03993.pdf) can serve as a guiding theoretical principle on how to implement such a standard. More specifically, we can draw inspiration from the existing model card schema's and implementations of [VerifyML](https://github.com/cylynx/verifyml?tab=readme-ov-file) and [Hugging Face](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool). We note the following:
+1. None of these two standards capture algorithmic assessments.
+2. Only VerifyML has a specific format to capture some technical tests.
 
+Hence in any case we need to extend one of these standards. We propose to:
+
+1. Assess and compare these two standards
+2. Chose the most appropriate one to extend
+3. Extend (and possibly adjust) this standard to our own standard (in the form of a basic schema) that allows for capturing algorithmic assessments and standardizes the way technical tests can be captured.

--- a/docs/Projects/TAD/reporting_standards.md
+++ b/docs/Projects/TAD/reporting_standards.md
@@ -1,43 +1,64 @@
 # TAD Reporting standards
+
 This document assesses standards that standardize the way algorithm assessments can be captured.
 
 ## Background
-There are many algorithm assessments (e.g. IAMA, HUIDERIA, etc.), technical tests on performance (e.g. Accuracy, TP, FP, F1, etc),
-fairness and bias of algorithms (e.g. SHAP) and reporting formats available. The goal is to have a way of standardizing the way these different
-assessments and tests can be captured.
+
+There are many algorithm assessments (e.g. IAMA, HUIDERIA, etc.), technical tests on performance (e.g. Accuracy, TP, FP,
+F1, etc), fairness and bias of algorithms (e.g. SHAP) and reporting formats available. The goal is to have a way of
+standardizing the way these different assessments and tests can be captured.
 
 ## Available standards
 
 ### Model Cards
-The most interesting existing capturing methods seem to be all based on [Model Cards for Model Reporting](https://arxiv.org/pdf/1810.03993.pdf),
-which are:
->"Short documents accompanying trained machine learning models that provide benchmarked evaluation in a variety of conditions,
->such as across different cultural, demographic, or phenotypic groups (e.g., race, geographic location, sex, Fitzpatrick skin type) and
->intersectional groups (e.g., age and race, or sex and Fitzpatrick skin type) that are relevant to the intended application domains. Model
->cards also disclose the context in which models are intended to be used, details of the performance evaluation procedures, and other relevant information",
->proposed by Google. Note that "The proposed set of sections" in the Model Cards paper "are intended to provide relevant details to consider, but are not intended to be complete or
->exhaustive, and may be tailored depending on the model, context, and stakeholders."
 
-Many companies implement their own version of Model Cards, for example 
-[Meta System Cards](https://ai.meta.com/blog/system-cards-a-new-resource-for-understanding-how-ai-systems-work/) (with accompanying 
-[Research Paper](https://scontent-ams2-1.xx.fbcdn.net/v/t39.2365-6/277534097_2440637952739403_7120117370014241056_n.pdf?_nc_cat=110&ccb=1-7&_nc_sid=3c67a6&_nc_ohc=Aninj9n8dZkAX-taf6n&_nc_oc=AQljYgl-KvN8tKF_A8bcdgcBT_deV0wFzI06r_P7sZODn4m3T3YUJKVb1SWDGtdjOus&_nc_ht=scontent-ams2-1.xx&oh=00_AfAhz7YW2blPavGIzs-cOXyLMQnb-xjkc4nTuT4zKdif6w&oe=65F48231)) and the tools mentioned in the next section.
+The most interesting existing capturing methods seem to be all based on
+[Model Cards for Model Reporting](https://arxiv.org/pdf/1810.03993.pdf), which are:
+>"Short documents accompanying trained machine learning models that provide benchmarked evaluation in a variety of
+>conditions, such as across different cultural, demographic, or phenotypic groups (e.g., race, geographic location,
+>sex, Fitzpatrick skin type) and intersectional groups (e.g., age and race, or sex and Fitzpatrick skin type) that are
+>relevant to the intended application domains. Model cards also disclose the context in which models are intended to be
+>used, details of the performance evaluation procedures, and other relevant information", proposed by Google. Note that
+>"The proposed set of sections" in the Model Cards paper "are intended to provide relevant details to consider, but are
+>not intended to be complete or exhaustive, and may be tailored depending on the model, context, and stakeholders."
+
+Many companies implement their own version of Model Cards, for example
+[Meta System Cards](https://ai.meta.com/blog/system-cards-a-new-resource-for-understanding-how-ai-systems-work/) and the
+tools mentioned in the next section.
 
 #### Automatic model card generation
+
 There exist tools to (semi)-automatically generate models cards:
-1. [Model Card Generator by US Sensus Bureau](https://bias.xd.gov/resources/model-card-generator/). Basic UI to create model cards and export to markdown, also hase a command line tool.
-2. [Model Card Toolkit by Google](https://blog.research.google/2020/07/introducing-model-card-toolkit-for.html). Automation only comes from integration with [TensorFlowExtended](https://www.tensorflow.org/tfx) and [ML Metadata](https://www.tensorflow.org/tfx/guide/mlmd).
-3. [VerifyML](https://github.com/cylynx/verifyml?tab=readme-ov-file). Based on the Google toolkit, but is extended to include specific tests on fairness and bias. Technical tests can be added by users and model card schema (in protobuf) can be extended by users.
-4. [Experimental Model Cards Writing Tool by Hugging Face](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool). This is the implementation of the Google paper by Hugging Face and provides information on the models available on their platform. The writing tools guides users through their model card and allows for up- and downloading from and to markdown.
+
+1. [Model Card Generator by US Sensus Bureau](https://bias.xd.gov/resources/model-card-generator/). Basic UI to create
+model cards and export to markdown, also hase a command line tool.
+2. [Model Card Toolkit by Google](https://blog.research.google/2020/07/introducing-model-card-toolkit-for.html).
+Automation only comes from integration with [TensorFlowExtended](https://www.tensorflow.org/tfx) and
+[ML Metadata](https://www.tensorflow.org/tfx/guide/mlmd).
+3. [VerifyML](https://github.com/cylynx/verifyml?tab=readme-ov-file). Based on the Google toolkit, but is extended to
+include specific tests on fairness and bias. Technical tests can be added by users and model card schema (in protobuf)
+can be extended by users.
+4. [Experimental Model Cards Tool by Hugging Face](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool).
+This is the implementation of the Google paper by Hugging Face and provides information on the models available on their
+platform. The writing tools guides users through their model card and allows for up- and downloading from and to
+markdown.
 
 ### Other standards
-[A landscape analysis of machine learning documentation tools](https://huggingface.co/docs/hub/en/model-card-landscape-analysis) has been
-performed by Hugging Face and provides a good overview of the current landscape.
 
-Another interesting standard is the [Algorithmic Transparency Recording Standard (ATRS)](https://www.gov.uk/government/publications/algorithmic-transparency-template)
-of the United Kingdom Goverment. 
+[A landscape analysis of ML documentation tools](https://huggingface.co/docs/hub/en/model-card-landscape-analysis)
+has been performed by Hugging Face and provides a good overview of the current landscape.
+
+Another interesting standard is the Algorithmic Transparency Recording Standard of the United Kingdom Goverment,
+which can be found [here](https://www.gov.uk/government/publications/algorithmic-transparency-template).
 
 ## Proposal
-We need a standard that captures algorithmic assessments and technical tests on model and datasets. The idea of [model cards](https://arxiv.org/pdf/1810.03993.pdf) can serve as a guiding theoretical principle on how to implement such a standard. More specifically, we can draw inspiration from the existing model card schema's and implementations of [VerifyML](https://github.com/cylynx/verifyml?tab=readme-ov-file) and [Hugging Face](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool). We note the following:
+
+We need a standard that captures algorithmic assessments and technical tests on model and datasets. The idea of
+[model cards](https://arxiv.org/pdf/1810.03993.pdf) can serve as a guiding theoretical principle on how to implement
+such a standard. More specifically, we can draw inspiration from the existing model card schema's and implementations of
+[VerifyML](https://github.com/cylynx/verifyml?tab=readme-ov-file) and
+[Hugging Face](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool). We note the following:
+
 1. None of these two standards capture algorithmic assessments.
 2. Only VerifyML has a specific format to capture some technical tests.
 
@@ -45,4 +66,5 @@ Hence in any case we need to extend one of these standards. We propose to:
 
 1. Assess and compare these two standards
 2. Chose the most appropriate one to extend
-3. Extend (and possibly adjust) this standard to our own standard (in the form of a basic schema) that allows for capturing algorithmic assessments and standardizes the way technical tests can be captured.
+3. Extend (and possibly adjust) this standard to our own standard (in the form of a basic schema) that allows for
+capturing algorithmic assessments and standardizes the way technical tests can be captured.

--- a/docs/Projects/TAD/reporting_standards.md
+++ b/docs/Projects/TAD/reporting_standards.md
@@ -1,0 +1,37 @@
+# TAD Reporting standards
+This document assesses standards that standardize the way algorithm assessments can be captured.
+
+## Background
+There are many algorithm assessments (IAMA, HUIDERIA, etc.), technical tests on performance (Accuracy, TP, FP, F1, etc),
+fairness and bias of algorithms (SHAP) and reporting formats available. The goal is to have a way of standardizing the way these different
+assessments and tests can be captured. 
+
+## Available standards
+
+### Model Cards
+The most interesting existing capturing method seems to be [Model Cards for Model Reporting](https://arxiv.org/pdf/1810.03993.pdf),
+which are "short documents accompanying trained machine learning models that provide benchmarked evaluation in a variety of conditions,
+such as across different cultural, demographic, or phenotypic groups (e.g., race, geographic location, sex, Fitzpatrick skin type) and
+intersectional groups (e.g., age and race, or sex and Fitzpatrick skin type) that are relevant to the intended application domains. Model
+cards also disclose the context in which models are intended to be used, details of the performance evaluation procedures, and other relevant information",
+proposed by Google.
+
+An [implementation](https://huggingface.co/docs/hub/en/model-cards) of this paper exists on Hugging Face and is the standard way Hugging Face
+provides information on the models available on their platform. Their [experimental tool](https://huggingface.co/spaces/huggingface/Model_Cards_Writing_Tool)
+provides a UI to create a model card. Although the UI of this tool can certainly be improved, it might be the best starting point as a way 
+to standardize algorithm assessments. Also the tool allows for up- and dowloading assessments from and to markdown. 
+
+### Other standards
+[A landscape analysis of machine learning documentation tools](https://huggingface.co/docs/hub/en/model-card-landscape-analysis) has been
+performed by Hugging Face and provides a good overview of the current landscape.
+
+Another interesting standard is the [Algorithmic Transparency Recording Standard (ATRS)](https://www.gov.uk/government/publications/algorithmic-transparency-template)
+of the United Kingdom Goverment. 
+
+
+## Proposal
+Take the Hugging Face Model Cards as a base for our own standard. The Model Cards needs to be extended to be able to caputre 
+assessments like IAMA. The above mentioned experimental tool can be a good example of the functionalities that we would like
+to have in to process our standard, although the tool can certainly be improved for example by supporting de/serialization
+to different formats and by adjusting availbe evaluation, fairness and bias tests depending on the chosen model task.
+


### PR DESCRIPTION
Contains a overview of ways model performance is reported, specifically in the form of so called model cards. We give a list of existing model cards and tools and propose next steps.