### PR TITLE
Disable auto fix commits from pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,8 @@ repos:
     rev: v0.39.0
     hooks:
       - id: markdownlint
+
+ci:
+  autofix_prs: false
+  autofix_commit_msg: 'Auto fix pre-commit.com hooks'
+  autoupdate_commit_msg: 'Update .pre-commit-config.yaml'


### PR DESCRIPTION
# Description

I would like to disable autofixing from pre-commit since it clutters the commit history and developers should have run it before commiting. The result should be that the CI/CD fails. 

If you want to autofix it anyway, you could use the command in an comment:
```shell
pre-commit.ci autofix
```