### PR TITLE
Tad reporting standard

### DIFF
--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -1,11 +1,14 @@
 # TAD Reporting Standard
 
-Version 0.1
+**Version**: 0.1a1
 
-This document describes the Transparancy of Algorithmic Decision Making (TAD) reporting standard. Assessing
-fairness and bias in Machine Learning models can be done through various technical tests, but also by answering
-regulatory assessments. The goal of this reporting standard is to capture these technical tests and assessments
-in a standardised way.
+This document describes the **T**ransparency of **A**lgorithmic **D**ecision making (TAD) Reporting Standard.
+
+For reproducibility, governance, auditing and sharing of algorithmic systems it is essential to have a
+reporting standard so that information about an algorithmic system can be shared. This reporting standard
+describes how information about the different phases of an algorithm's life cycle can be reported.
+It contains, among other things, descriptive information combined with information about the technical
+tests and assessments applied.
 
 ## Disclaimer
 
@@ -14,9 +17,9 @@ and will change significantly in future versions.
 
 ## Introduction
 
-Inspired by [Papers with Code Model Index](https://github.com/paperswithcode/model-index) and
-[Model Cards for Model Reporting](https://arxiv.org/abs/1810.03993) this standard almost [^1] [^2] [^3] [^4]
-extends the [Hugging Face model card metadata specification](https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1)
+Inspired by [Model Cards for Model Reporting](https://arxiv.org/abs/1810.03993)
+and [Papers with Code Model Index](https://github.com/paperswithcode/model-index) this standard almost
+[^1] [^2] [^3] [^4] extends the [Hugging Face model card metadata specification](https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1)
 to allow for:
 
 1. More finegrained information on performance metrics, by extending the `metrics_field` from the Hugging
@@ -28,15 +31,16 @@ by defining an new field `measurements`.
 and [ALTAI](https://digital-strategy.ec.europa.eu/en/library/assessment-list-trustworthy-artificial-intelligence-altai-self-assessment)).
 This is achieved by defining a new field `assessments`.
 
-This standard does not contain all fields present in the Hugging Face metadata specification. The fields that
-are optional in the HuggingFace specification AND are specific to the HugginFace interface are ommited.
-
 Following Hugging Face, this proposed standard will be written in yaml.
 
-Another difference is that we devide our implementation into two parts.
+This standard does not contain all fields present in the Hugging Face metadata specification. The fields that
+are optional in the HuggingFace specification and are specific to the HugginFace interface are ommited.
+
+Another difference is that we devide our implementation into three seperate parts.
 
 1. `systems_card`, containing information about a group of ML-models which accomplish a specific task.
 2. `model_card`, containing information about a specific ML-model.
+3. `assessment_card`, containing information about a regulatory assessment.
 
 ## Intended usage
 
@@ -45,55 +49,82 @@ the Hugging Face metadata.
 
 ## Specification of the standard
 
-The standard will be written in yaml. An example yaml is given in the next section. The standard defines
-two 'cards': a `system_card` and a `model_card`.
+The standard will be written in yaml. Example yaml files are given in the next section. The standard defines
+three cards: a `system_card`, a `model_card` and an `assessment_card`. A `system_card` contains information
+about an algorithmic system. It can have mutiple models and each of these models should have a `model_card`.
+Regulatory assessments can be processed in an `assessment_card`. Note that `model_card`'s and
+`assessment_card`'s can be included directly into the `system_card` or can be included as seperate yaml
+files with help of a yaml-include mechanism. For clarity the latter is preffered and is also used in
+the examples in the next section.
 
 ### `system_card`
 
 A `system_card` contains the following information.
 
-1. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
+1. `name` (OPTIONAL, string). Name used to describe the system.
+2. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
     it should contain a URI from the [Uniform Product List](https://standaarden.overheid.nl/owms/oquery/UPL-actueel.plain).
-2. `owners` (list). There can be multiple owners. For each owner the following fields are present.
+3. `owners` (list). There can be multiple owners. For each owner the following fields are present.
 
-    1. `organization` (REQUIRED, string). Name of the organization that owns the model.
-    2. `oin` (OPTIONAL, string). If applicable the [Organisatie-identificatienummer (OIN)](https://www.logius.nl/domeinen/toegang/organisatie-identificatienummer/wat-is-het).
+    1. `oin` (OPTIONAL, string). If applicable the [Organisatie-identificatienummer (OIN)](https://oinregister.logius.nl/oin-register).
+    2. `organization` (OPTIONAL, string). Name of the organization that owns the model. If `ion` is
+    NOT provided this field is REQUIRED.
     3. `name` (OPTIONAL, string). Name of a contact person within the organisation.
     4. `email` (OPTIONAL, string). Email address of the contact person or organization.
     5. `role` (OPTIONAL, string). Role of the contact person. This field should only be set when the `name` field
     is set.
 
-#### 2. Models
+4. `description` (OPTIONAL, string). A short description of the system.
+5. `labels` (OPTIONAL, list). This fields allows to store meta information about a system. There
+can be multiple labels. For each label the following fields are present.
+
+    1. `name` (OPTIONAL, string). Name of the label.
+    2. `value` (OPTIONAL, string). Value of the label.
+
+6. `status` (OPTIONAL, string). The status of the system. For example the status can be "production".
+7. `publication_category` (OPTIONAL, enum[string]). The publication category of the algorithm should
+be chosen from `["high_risk", other"]`.
+8. `begin_date` (OPTIONAL, string). The first date the system was used.
+Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. YYYY-MM-DD.
+9. `end_date` (OPTIONAL, string). The last date the system was used.
+Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. YYYY-MM-DD.
+10. `goal_and_impact` (OPTIONAL, string). The purpose of the system and the impact it has on citizens
+and companies.
+11. `considerations` (OPTIONAL, string). The pro's and con's of using the system.
+12. `risk_management` (OPTIONAL, string). Description of the risks associated with the system.
+13. `human_intervention` (OPTIONAL, string). A description to want extend there is human involvement
+in the system.
+14. `legal_base` (OPTIONAL, list). If there exists a legal base for the process the system is embedded
+in, this field can be filled in with the relevant laws. There can be multiple legal bases. For each
+legal base the following fields are present.
+    1. `name` (OPTIONAL, string). Name of the law.
+    2. `link` (OPTIONAL, string). URI pointing towards the contents of the law.
+15. `used_data` (OPTIONAL, string). An overview of the data that is used in the system.
+16. `technical_design` (OPTIONAL, string). Description on how the system works.
+17. `external_providers` (OPTIONAL, list[string]). Name of an external provider, if relevant. There can
+be multiple external providers.
+18. `references` (OPTIONAL, list[string]). Additional reference URI's that point information about the system
+and are relevant.
+
+#### 1. Models
 
 1. `models` (OPTIONAL, list[ModelCard]). A list of model cards (as defined below) or `!include`s of a yaml
 file containing a model card. This model card can for example be a model card described in the next section
 or a model card from Hugging Face. There can be multiple model cards, meaning multiple models are used.
 
-#### 3. Assessments
+#### 2. Assessments
 
-There can be multiple assessments. For each assessment the following fields are present:
-
-1. `name` (REQUIRED). The name of the assessment.
-2. `date` (REQUIRED). The date at which the assessment is completed.
-3. `contents`. There can be multiple items in contents. For each item the following fields are present:
-
-    1. `question` (REQUIRED). A question.
-    2. `answer` (REQUIRED). An answer.
-    3. `remarks` (OPTIONAL). A field to put relevant discussion remarks in.
-    4. `authors`. There can be multiple names. For each name the following field is present.
-        1. `name` (OPTIONAL). The name of the author of the question.
-    5. `timestamp` (OPTIONAL). A timestamp of the date and time of the answer.
+1. `assessments` (OPTIONAL, list[AssesmentCard]). A list of assessment cards (as defined below) or `!include`s of a yaml
+file containing a assessment card. This assessment card is an assessment card described in the next section.
+There can be multiple assessment cards, meaning multiple assessment were performed.
 
 ### `model_card`
 
 A `model_card` contains the following information.
 
-1. `algorithm-registers` (OPTIONAL, list[string]). If this algorithm is registered in an algorithm register,
-this field should contain a URI to the corresponding record in the register. There can be multiple registers.
-A URI could look like `https://huggingface.co/org/modelid` or `https://algoritmes.overheid.nl/nl/algoritme/modelid`.
-2. `language` (OPTIONAL, list[string]). If relevant, the natural languages the model supports in [ISO 639](https://www.iso.org/iso-639-language-code).
+1. `language` (OPTIONAL, list[string]). If relevant, the natural languages the model supports in [ISO 639](https://www.iso.org/iso-639-language-code).
     There can be multiple languages.
-3. `license`(REQUIRED, string). Any license from the [open source license list](https://opensource.org/license)
+2. `license`(REQUIRED, string). Any license from the [open source license list](https://opensource.org/license)
 [^1]. If the license is NOT present in the license list this field must be set to 'other' and the following
 two fields will be REQUIRED.
 
@@ -101,15 +132,18 @@ two fields will be REQUIRED.
     2. `license_link` (string). A link to a file of that name inside the repo, or a URL to a remote file containing the license
     contents.
 
-4. `library_name` (OPTIONAL, string). Any library from the [library list](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts).
-    If the library is NOT present in the library list, the following fields CAN be set.
-    1. `library` (OPTIONAL, string). If a library is used that is not in the above list, you can provide
-    the name of the library used here.
-    2. `library_link` (OPTIONAL, string). If a libary is used that is not in the above list, you can
-    provide a URI to the repo of the library used here.
-5. `tags` (OPTIONAL, list[string]). Tags with keywords to describe the project. There can be multiple tags.
+3. `tags` (OPTIONAL, list[string]). Tags with keywords to describe the project. There can be multiple tags.
+4. `owners` (list). There can be multiple owners. For each owner the following fields are present.
 
-#### `model_index`
+    1. `oin` (OPTIONAL, string). If applicable the [Organisatie-identificatienummer (OIN)](https://oinregister.logius.nl/oin-register).
+    2. `organization` (OPTIONAL, string). Name of the organization that owns the model. If `ion` is
+    NOT provided this field is REQUIRED.
+    3. `name` (OPTIONAL, string). Name of a contact person within the organisation.
+    4. `email` (OPTIONAL, string). Email address of the contact person or organization.
+    5. `role` (OPTIONAL, string). Role of the contact person. This field should only be set when the `name` field
+    is set.
+
+#### 1. Model Index
 
 There can be multiple models. For each model the following fields are present.
 
@@ -122,15 +156,22 @@ artifact, that cannot be captured by any other field, but are relevant to model.
     1. `name` (REQUIRED, string). The name of the parameter, for example "epochs".
     2. `dtype` (OPTIONAL, string). The datatype of the parameter, for example "int".
     3. `value` (OPTIONAL, string). The value of the parameter, for example 100.
+    4. `labels` (list). This field allows to store meta information about a parameter.
+        There can be multiple labels. For each label the following fields are present.
+
+        1. `name` (OPTIONAL, string). The name of the label.
+        2. `dtype` (OPTIONAL, string). The datatype of the feature. If `name` is set, this field
+        is REQUIRED.
+        3. `value` (OPTIONAL, string). The value of the feature. If `name` is set, this field is REQUIRED.
 
 5. `results` (list). There can be multiple results. For each result the following fields are present.
 
-    1. `task` (list).
+    1. `task` (OPTIONAL, list).
 
         1. `task_type` (REQUIRED, string). The task of the model, for example "object-classifcation".
         2. `task_name` (OPTIONAL, string). A pretty name fo the model taks, for example "Object Classification".
 
-    2. `dataset` (list). There can be multiple results [^2]. For each result the following fields are present.
+    2. `datasets` (list). There can be multiple datasets [^2]. For each dataset the following fields are present.
 
         1. `type` (REQUIRED, string). The type of the dataset, can be a dataset id from [HuggingFace datasets](https://hf.co/datasets)
         or any other link to a repository containing the dataset[^3], for example "common_voice".
@@ -145,19 +186,19 @@ artifact, that cannot be captured by any other field, but are relevant to model.
         2. `name` (REQUIRED, string). A descriptive name of the metric. For example "false positive rate" is
         not a descriptive name, but "training false positive rate w.r.t class x" is.
         3. `dtype` (REQUIRED, string). The data type of the metric, for example `float`.
-        4. `value` (REQUIRED, float). The value of the metric.
-        5. `class` (OPTIONAL, string/int/float/bool). Some metrics (such as false positive rate for multiclass classification)
-        depend on a specific output class. In this field the output class can be specified. It must only be set for metrics
-        for which it makes sense.
-        6. `labels` (list). Metrics can be computed for example on subgroups of specific features.
-        For example one can compute the accuracy for examples where the feature "gender" is set to "male".
+        4. `value` (REQUIRED, string). The value of the metric.
+        5. `labels` (list). This field allows to store meta information about a metric. For example,
+        metrics can be computed for example on subgroups of specific features.
+        For example, one can compute the accuracy for examples where the feature "gender" is set to "male".
         There can be multiple subgroups, which means that the metric is computed on the intersection of those subgroups.
-        For each subgroup the following fields are present.
+        There can be multiple labels. For each label the following fields are present.
 
             1. `name` (OPTIONAL, string). The name of the feature. For example: "gender".
-            2. `type` (OPTIONAL, string). The datatype of the feature, for example `float`. If `name` is set, this field
-            must be set as well.
-            3. `value` (OPTIONAL, string). The value of the feature. If `name` is set, this field must be set as wel.
+            2. `type` (OPTIONAL, string). The type of the label. Can for example be set to "feature" or "output_class".
+            If `name` is set, this field is REQUIRED.
+            3. `dtype` (OPTIONAL, string). The datatype of the feature, for example `float`. If `name` is set, this field
+            is REQUIRED.
+            4. `value` (OPTIONAL, string). The value of the feature. If `name` is set, this field is REQUIRED.
             For example: "male".
 
     4. `measurements`.
@@ -188,49 +229,72 @@ artifact, that cannot be captured by any other field, but are relevant to model.
                     1. `x_value` (REQUIRED, float). The $x$-value of the graph.
                     2. `y_value` (REQUIRED, float). The $y$-value of the graph.
 
+### `assessment_card`
+
+An `assessment_card` contains the following information.
+
+1. `name` (REQUIRED, string). The name of the assessment.
+2. `date` (REQUIRED, string). The date at which the assessment is completed.
+Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. YYYY-MM-DD.
+3. `contents` (list). There can be multiple items in contents. For each item the following fields are present:
+
+    1. `question` (REQUIRED, string). A question.
+    2. `answer` (REQUIRED, string). An answer.
+    3. `remarks` (OPTIONAL, string). A field to put relevant discussion remarks in.
+    4. `authors`. There can be multiple names. For each name the following field is present.
+        1. `name` (OPTIONAL, string). The name of the author of the question.
+    5. `timestamp` (OPTIONAL, string). A timestamp of the date and time of the answer.
+
 ## Example
 
 ### System Card
 
 ```yaml
+name: {system_name}                                     # Optional. Example: "AangifteVertrekBuitenland"
 upl: {upl_uri}                                          # Optional. Example: https://standaarden.overheid.nl/owms/terms/AangifteVertrekBuitenland
 owners:
-- organization: {organization_name}                     # Required. Example: BZK
-  oin: {oin}                                            # Optional. Example: 00000001003214345000
+- oin: {oin}                                            # Optional. Example: 00000001003214345000
+  organization: {organization_name}                     # Optional if oin is provided, Required otherwise. Example: BZK
   name: {owner_name}                                    # Optional. Example: John Doe
   email: {owner_email}                                  # Optional. Example: johndoe@email.com
   role: {owner_role}                                    # Optional. Example: Data Scientist.
+description: {system_description}                       # Optional. Short description of the system.
+labels:                                                 # Optional labels to store metadata about the system.
+- name: {label_name}                                    # Optional.
+  value: {label_value}                                  # Optional.
+status: {system_status}                                 # Optional. Example "production".
+publication_category: {system_publication_cat}          # Optional. Example: "impactfull_algorithm".
+begin_date: {system_begin_date}                         # Optional. Example: 2025-1-1.
+end_date: {system_end_date}                             # Optional. Example: 2025-12-1.
+goal_and_impact: {system_goal_and_impact}               # Optional. Goal and impact of the system.
+considerations: {system_considerations}                 # Optional. Considerations about the system.
+risk_management: {system_risk_management}               # Optional. Description of risks associated with the system.
+human_intervention: {system_human_intervention}         # Optional. Description of uman involvement in the system.
+legal_base:
+- name: {law_name}                                      # Optional. Example: "AVG".
+  link: {law_uri}                                       # Optional. Example: "https://eur-lex.europa.eu/legal-content/NL/TXT/HTML/?uri=CELEX:31995L0046".
+used_data: {system_used_data}                           # Optional. Description of the data used by the system.
+technical_design: {technical_design}                    # Optional. Description of the technical design of the system.
+external_providers:
+- {system_external_provider}                            # Optional. Reference to used external providers.
+references:
+- {reference_uri}                                       # Optional. Example: URI to codebase.
 
-# Model Cards
 models:
- - !include {model_card_uri}                            # Optional. Example: model_card.yaml.
+ - !include {model_card_uri}                            # Optional. Example: cat_classifier_model.yaml.
 
-# Assessments like IAMA.
 assessments:
-- name: {assessment_name}                               # Required. Example: IAMA.
-  date: {assessment_date}                               # Required. Example: 25-03-2025.
-  contents:
-    - question: {question_text}                         # Required. Example: "Question 1: ...".
-      answer: {answer_text}                             # Required. Example: "Answer: ...".
-      remarks: {remarks_text}                           # Optional. Example: "Remarks: ...".
-      authors:                                          # Optional. Example: "['John', 'Peter']".
-        - name: {author_name}
-      timestamp: {timestamp}                            # Optional. Example: 1711630721.
+- !include {assessment_card_uri}                        # Required. Example: iama.yaml.
 ```
 
 ### Model Card
 
 ```yaml
-algorithm-registers:
-  - {id}                                                # Optional. Example: https://algoritmes.overheid.nl/nl/algoritme/45991543.
 language:
   - {lang_0}                                            # Optional. Example nl.
 license: {licence}                                      # Required. Example: Apache-2.0 or any license SPDX ID from https://opensource.org/license or "other".
-license_name: {licence_name}                            # Required. if license = other, specify an id for the licence. Example: 'my-license-1.0'
-license_link: {license_link}                            # Required. if license = other, specify "LICENSE" or "LICENSE.md" to link to a file of that name inside the repo, or a URL to a remote file.
-library_name: {library_name}                            # Optional. Example: keras or any library from https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts.
-library: {library_name}                                 # Optional. Example: mylibrary
-library_link: {library_link}                            # Optional. URI to user provided library.
+license_name: {licence_name}                            # Optional if license != other, Required otherwise. Example: 'my-license-1.0'
+license_link: {license_link}                            # Optional if license != other, Required otherwise. Specify "LICENSE" or "LICENSE.md" to link to a file of that name inside the repo, or a URL to a remote file.
 tags:
 - {tag_0}                                               # Optional. Example: audio
 - {tag_1}                                               # Optional. Example: automatic-speech-recognition
@@ -250,11 +314,15 @@ model-index:
   - name: {parameter_name}                              # Optional. Example: "epochs".
     dtype: {parameter_dtype}                            # Optional. Example "int".
     value: {parameter_value}                            # Optional. Example 100.
+    labels:
+      - name: {label_name}                              # Optional. Example: "gender".
+        dtype: {label_type}                             # Optional. Example: "string".
+        value: {label_value}                            # Optional. Example: "female".
   results:
   - task:
       type: {task_type}                                 # Required. Example: image-classification.
       name: {task_name}                                 # Optional. Example: Image Classification.
-    dataset:
+    datasets:
       - type: {dataset_type}                            # Required. Example: common_voice. Link to a repository containing the dataset
         name: {dataset_name}                            # Required. Example: "Common Voice (French)". A pretty name for the dataset.
         split: {split}                                  # Optional. Example "train".
@@ -266,11 +334,11 @@ model-index:
       name: {metric_name}                               # Required. Example: "FPR wrt class 0 restricted to feature gender:0 and age:21".
       dtype: {metric_dtype}                             # Required. Example: "float".
       value: {metric_value}                             # Required. Example: 0.75.
-      class: {metric_output_class}                      # Optional. Example: "1". Only relevant for certain metrics such as for example false-positive-rate positive rate.
       labels:
-        - name: {feature_name}                          # Optional. Example: "gender".
-          type: {feature_type}                          # Optional. Example: "string".
-          value: {feature_value}                        # Optional. Example: "female".
+        - name: {label_name}                            # Optional. Example: "gender".
+          type: {label_type}                            # Optional. Exmple "feature".
+          dtype: {label_type}                           # Optional. Example: "string".
+          value: {label_value}                          # Optional. Example: "female".
     measurements:
       # Bar plots should be able to capture SHAP and Robustness Toolbox from AI Verify.
       bar_plots:
@@ -293,6 +361,20 @@ model-index:
               y_value: {y_value}                        # Required. The y value of the graph data.
 
 ```
+
+### Assessment Card
+
+```yaml
+name: {assessment_name}                               # Required. Example: IAMA.
+date: {assessment_date}                               # Required. Example: 25-03-2025.
+contents:
+  - question: {question_text}                         # Required. Example: "Question 1: ...".
+    answer: {answer_text}                             # Required. Example: "Answer: ...".
+    remarks: {remarks_text}                           # Optional. Example: "Remarks: ...".
+    authors:                                          # Optional. Example: "['John', 'Peter']".
+      - name: {author_name}
+    timestamp: {timestamp}                            # Optional. Example: 1711630721.
+````
 
 ## Schema
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -38,9 +38,16 @@ are optional in the HuggingFace specification and are specific to the HugginFace
 
 Another difference is that we devide our implementation into three seperate parts.
 
-1. `systems_card`, containing information about a group of ML-models which accomplish a specific task.
+1. `system_card`, containing information about a group of ML-models which accomplish a specific task.
 2. `model_card`, containing information about a specific ML-model.
 3. `assessment_card`, containing information about a regulatory assessment.
+
+!!! note "Include statements"
+
+    These `model_card`s and  `assessment_card`s  can be included verbatim into a `system_card`,
+    or referenced with an `!include` statement, allowing for minimal cards to be compact and in a
+    single file, but for extensive cards to be split up for readability and maintainability.
+    Our standard allows for the `!include` to be used anywhere.
 
 ## Intended usage
 
@@ -61,10 +68,11 @@ the examples in the next section.
 
 A `system_card` contains the following information.
 
-1. `name` (OPTIONAL, string). Name used to describe the system.
-2. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
+1. `schema_version` (REQUIRED, string). Version of the schema used, for example "0.1a1".
+2. `name` (OPTIONAL, string). Name used to describe the system.
+3. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
     it should contain a URI from the [Uniform Product List](https://standaarden.overheid.nl/owms/oquery/UPL-actueel.plain).
-3. `owners` (list). There can be multiple owners. For each owner the following fields are present.
+4. `owners` (list). There can be multiple owners. For each owner the following fields are present.
 
     1. `oin` (OPTIONAL, string). If applicable the [Organisatie-identificatienummer (OIN)](https://oinregister.logius.nl/oin-register).
     2. `organization` (OPTIONAL, string). Name of the organization that owns the model. If `ion` is
@@ -74,36 +82,36 @@ A `system_card` contains the following information.
     5. `role` (OPTIONAL, string). Role of the contact person. This field should only be set when the `name` field
     is set.
 
-4. `description` (OPTIONAL, string). A short description of the system.
-5. `labels` (OPTIONAL, list). This fields allows to store meta information about a system. There
+5. `description` (OPTIONAL, string). A short description of the system.
+6. `labels` (OPTIONAL, list). This fields allows to store meta information about a system. There
 can be multiple labels. For each label the following fields are present.
 
     1. `name` (OPTIONAL, string). Name of the label.
     2. `value` (OPTIONAL, string). Value of the label.
 
-6. `status` (OPTIONAL, string). The status of the system. For example the status can be "production".
-7. `publication_category` (OPTIONAL, enum[string]). The publication category of the algorithm should
+7. `status` (OPTIONAL, string). The status of the system. For example the status can be "production".
+8. `publication_category` (OPTIONAL, enum[string]). The publication category of the algorithm should
 be chosen from `["high_risk", other"]`.
-8. `begin_date` (OPTIONAL, string). The first date the system was used.
+9. `begin_date` (OPTIONAL, string). The first date the system was used.
 Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. YYYY-MM-DD.
-9. `end_date` (OPTIONAL, string). The last date the system was used.
+10. `end_date` (OPTIONAL, string). The last date the system was used.
 Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. YYYY-MM-DD.
-10. `goal_and_impact` (OPTIONAL, string). The purpose of the system and the impact it has on citizens
+11. `goal_and_impact` (OPTIONAL, string). The purpose of the system and the impact it has on citizens
 and companies.
-11. `considerations` (OPTIONAL, string). The pro's and con's of using the system.
-12. `risk_management` (OPTIONAL, string). Description of the risks associated with the system.
-13. `human_intervention` (OPTIONAL, string). A description to want extend there is human involvement
+12. `considerations` (OPTIONAL, string). The pro's and con's of using the system.
+13. `risk_management` (OPTIONAL, string). Description of the risks associated with the system.
+14. `human_intervention` (OPTIONAL, string). A description to want extend there is human involvement
 in the system.
-14. `legal_base` (OPTIONAL, list). If there exists a legal base for the process the system is embedded
+15. `legal_base` (OPTIONAL, list). If there exists a legal base for the process the system is embedded
 in, this field can be filled in with the relevant laws. There can be multiple legal bases. For each
 legal base the following fields are present.
     1. `name` (OPTIONAL, string). Name of the law.
     2. `link` (OPTIONAL, string). URI pointing towards the contents of the law.
-15. `used_data` (OPTIONAL, string). An overview of the data that is used in the system.
-16. `technical_design` (OPTIONAL, string). Description on how the system works.
-17. `external_providers` (OPTIONAL, list[string]). Name of an external provider, if relevant. There can
+16. `used_data` (OPTIONAL, string). An overview of the data that is used in the system.
+17. `technical_design` (OPTIONAL, string). Description on how the system works.
+18. `external_providers` (OPTIONAL, list[string]). Name of an external provider, if relevant. There can
 be multiple external providers.
-18. `references` (OPTIONAL, list[string]). Additional reference URI's that point information about the system
+19. `references` (OPTIONAL, list[string]). Additional reference URI's that point information about the system
 and are relevant.
 
 #### 1. Models
@@ -250,6 +258,7 @@ Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-fo
 ### System Card
 
 ```yaml
+version: {system_card_version}                          # Optional. Example: "0.1a1"
 name: {system_name}                                     # Optional. Example: "AangifteVertrekBuitenland"
 upl: {upl_uri}                                          # Optional. Example: https://standaarden.overheid.nl/owms/terms/AangifteVertrekBuitenland
 owners:

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -378,7 +378,7 @@ contents:
     authors:                                          # Optional. Example: "['John', 'Peter']".
       - name: {author_name}
     timestamp: {timestamp}                            # Optional. Example: 1711630721.
-````
+```
 
 ## Schema
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -102,7 +102,7 @@ two fields will be REQUIRED.
     provide a URI to the repo of the library used here.
 5. `tags` (OPTIONAL, list[string]). Tags with keywords to describe the project. There can be multiple tags.
 
-### 2. `model_index`
+#### `model_index`
 
 There can be multiple models. For each model the following fields are present.
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -58,7 +58,7 @@ A `system_card` contains the following information.
 
 #### 2. Models
 
-1. `models` (OPTIONAL, list[string]). A URI to a yaml file containg a model card. This model card can for example be a model
+1. `models` (OPTIONAL, list[ModelCard]). A list of model cards (as defined below) or `!include`s of a yaml file containing a model card. This model card can for example be a model
 card described in the next section or a model card from Hugging Face. There can be multiple model cards, meaning multiple
 models are used.
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -10,10 +10,10 @@ describes how information about the different phases of an algorithm's life cycl
 It contains, among other things, descriptive information combined with information about the technical
 tests and assessments applied.
 
-## Disclaimer
+!!! warning "Disclaimer"
 
-The TAD Reporting Standard is work in progress. This means that the current standard is probably suboptimal
-and will change significantly in future versions.
+    The TAD Reporting Standard is work in progress. This means that the current standard is probably suboptimal
+    and will change significantly in future versions.
 
 ## Introduction
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -1,0 +1,640 @@
+# TAD Reporting Standard
+
+This document describes the Transparancy of Algorithmic Decision Making (TAD) reporting standard.
+
+## Introduction
+
+The standard almost [^1] [^2] extends the [Hugging Face model card metadata specification](https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1)
+to allow for:
+
+1. More finegrained information on performance metrics, by extending the `metrics_field` from the Hugging
+Face metadata specification.
+2. Capturing additional *measurements* on fairness and bias, which can be partitioned into bar plot like
+measurements (such as mean absolute SHAP values) and graph plot like measurements (such as partial dependence). This is achieved
+by defining an new field `measurements`.
+3. Capturing *assessments* (such as IAMA). This is achieved by defining a new field `assessments`.
+
+This standard does not contain all fields present in the Hugging Face metadata specification. The fields that
+are optional in the HuggingFace specification AND are specific to the HugginFace interface are ommited.
+
+Following Hugging Face, this proposed standard will be written in yaml.
+
+## Intended usage
+
+The reporting standard defined in this document is intented to be given as a preamble in a model card, similar to
+the Hugging Face metadata.
+
+## Specification of the standard
+
+The standard will be written in yaml. An example yaml is given in the next section. The standard contains the
+following information.
+
+1. `algorithm-registers` (OPTIONAL, list[string]). If this algorithm is registered in an algorithm register,
+this field should contain a URI to the corresponding record in the register. There can be multiple registers.
+A URI could look like `https://huggingface.co/org/modelid` or `https://algoritmes.overheid.nl/nl/algoritme/modelid`.
+2. `language` (OPTIONAL, list[string]). If relevant, the natural languages the model supports in ISO 639.
+    There can be multiple languages.
+3. `license`(REQUIRED, string). Any license from the [license list](https://huggingface.co/docs/hub/repositories-licenses).
+If the license is NOT present in the license list this field must be set to 'other' and the following two fields will
+be REQUIRED.
+
+    1. `license_name` (string). An id for the license.
+    2. `license_link` (string). A link to a file of that name inside the repo, or a URL to a remote file containing the license
+    contents.
+
+4. `library` (OPTIONAL, string). Any library from the [library list](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts).
+5. `tags` (OPTIONAL, list[string]). Tags with keywords to describe the project. There can be multiple tags.
+6. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
+    it should contain a URI from the [Uniform Product List](https://standaarden.overheid.nl/owms/oquery/UPL-actueel.plain).
+7. `owners` (list). There can be multiple owners. For each owner the following fields are present.
+
+    1. `organization` (REQUIRED, string). Name of the organization that owns the model.
+    2. `oin` (OPTIONAL, string). If applicable the [Organisatie-identificatienummer (OIN)](https://www.logius.nl/domeinen/toegang/organisatie-identificatienummer/wat-is-het).
+    3. `name` (OPTIONAL, string). Name of a contact person within the organisation.
+    4. `email` (OPTIONAL, string). Email address of the contact person or organization.
+    5. `role` (OPTIONAL, string). Role of the contact person. This field should only be set when the `name` field
+    is set.
+
+### 2. `model_index`
+
+There can be multiple models. For each model the following fields are present.
+
+1. `name` (REQUIRED, string). The name of the model.
+2. `model` (REQUIRED, string). A URI pointing to a repository containing the model file.
+3. `results` (list). There can be multiple results. For each result the following fields are present.
+
+    1. `task` (list).
+
+        1. `task_type` (REQUIRED, string). The task of the model, for example "object-classifcation".
+        2. `task_name` (OPTIONAL, string). A pretty name fo the model taks, for example "Object Classification".
+
+    2. `dataset` (list).
+
+        1. `type` (REQUIRED, string). The type of the dataset, can be a dataset id from [HuggingFace datasets](https://hf.co/datasets)
+        or a link to a repository containing the dataset[^1], for example "common_voice".
+        2. `name` (REQUIRED, string). Name pretty name for the dataset, for example "Common Voice (French)".
+        3. `split` (OPTIONAL, string). The split of the dataset, for example "train".
+        4. `revision` (OPTIONAL, string). Version of the dataset, for example 5503434ddd753f426f4b38109466949a1217c2bb.
+
+    3. `metrics` (list). There can be multiple metrics. For each metric the following fields are present.
+
+        1. `type` (REQUIRED, string). A metric-id from [Hugging Face metrics](https://hf.co//metrics)[^2], for example accuracy.
+        2. `name` (REQUIRED, string). A descriptive name of the metric. For example "false positive rate" is
+        not a descriptive name, but "training false positive rate w.r.t class x" is.
+        3. `value` (REQUIRED, float). The value of the metric.
+        4. `class` (OPTIONAL, string/int/float/bool). Some metrics (such as false positive rate for multiclass classification)
+        depend on a specific output class. In this field the output class can be specified. It must only be set for metrics
+        for which it makes sense.
+        5. `subgroups` (list). Metrics can be computed on subgroups of specific features. For example one can compute the
+        accuracy for examples where the feature "gender" is set to "male".
+        There can be multiple subgroups, which means that the metric is computed on the intersection of those subgroups.
+        For each subgroup the following fields are present.
+
+            1. `feature` (OPTIONAL, string). The name of the feature. For example: "gender".
+            2. `group` (OPTIONAL, string). The value of the feature. If `feature` is set, this field must be set as wel.
+            For example: "male".
+
+    4. `measurements`.
+
+        1. `bar_plots` (list). The purpose of this field is to capute bar plot like measurements, for example SHAP values.
+        There can be multiple bar plots. For each bar plot the following fields are present.
+
+            1. `type` (REQUIRED, string). The type of bar plot, for example "SHAP".
+            2. `name` (OPTIONAL, string). A pretty name for the plot, for example "Mean Absolute SHAP Values".
+            3. `results` (list). The contents of the bar plot. A result represents a bar. There can be mutiple results.
+            For each result the following fields are present.
+                1. `name` (REQUIRED, string). The name of bar.
+                2. `value` (REQUIRED, float). The value of the corresponding bar.
+
+        2. `graph_plots` (list). The purpose of this field is to capture graph plot like measurements, such as partial dependence
+        plots.
+        There can be multiple graph plots. For each graph plot the following fields are present.
+
+            1. `type` (REQUIRED, string). The type of the graph plot, for example "partial_dependence".
+            2. `name` (OPTONAL, string). A pretty name of the graph, for example "Partial Dependence Plot".
+            3. `results` (list). Results contains the graph plot data. Each graph can depend on a specific output
+            class and feature. There can be multiple results. For each result the following fields are present.
+                1. `class` (OPTIONAL, string/int/float/bool). The output class name that the graph corresponds to.
+                This field is not always present.
+                2. `feature` (REQUIRED, string). The feature the graph corresponds to. This is required, since all
+                relevant graphs are dependend on features.
+                3. `data` (list)
+                    1. `x_value` (REQUIRED, float). The $x$-value of the graph.
+                    2. `y_value` (REQUIRED, float). The $y$-value of the graph.
+
+### 3. Assessments
+
+There can be multiple assessments. For each assessment the following fields are present:
+
+1. `name` (REQUIRED). The name of the assessment.
+2. `date` (REQUIRED). The date at which the assessment is completed.
+3. `contents`. There can be multiple items in contents. For each item the following fields are present:
+
+    1. `question` (REQUIRED). A question.
+    2. `answer` (REQUIRED). An answer.
+    3. `remarks` (OPTIONAL). A field to put relevant discussion remarks in.
+    4. `authors`. There can be multiple names. For each name the following field is present.
+        1. `name` (OPTIONAL). The name of the author of the question.
+    5. `timestamp` (OPTIONAL). A timestamp of the date and time of the answer.
+
+## Example
+
+```yaml
+algorithm-registers:
+  - {id}                                                # Optional. Example: https://algoritmes.overheid.nl/nl/algoritme/45991543.
+language:
+  - {lang_0}                                            # Optional. Example nl.
+license: {licence}                                      # Required. Example: apache-2.0 or any license identifier from https://huggingface.co/docs/hub/repositories-licenses
+license_name: {licence_name}                            # Required. if license = other, specify an id for the licence. Example: 'my-license-1.0'
+license_link: {license_link}                            # Required. if license = other, specify "LICENSE" or "LICENSE.md" to link to a file of that name inside the repo, or a URL to a remote file.
+library_name: {library_name}                            # Optional. Example: keras or any library from https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts.
+tags:
+- {tag_0}                                               # Optional. Example: audio
+- {tag_1}                                               # Optional. Example: automatic-speech-recognition
+upl: {upl_uri}                                          # Optional. Example: https://standaarden.overheid.nl/owms/terms/AangifteVertrekBuitenland
+owners:
+- organization: {organization_name}                     # Required. Example: BZK
+  oin: {oin}                                            # Optional. Example: 00000001003214345000
+  name: {owner_name}                                    # Optional. Example: John Doe
+  email: {owner_email}                                  # Optional. Example: johndoe@email.com
+  role: {owner_role}                                    # Optional. Example: Data Scientist.
+
+model-index:
+- name: {model_id}                                      # Required. Example: CatClassifier.
+  model: {model_uri}                                    # Required. URI to a repository containing the model file.
+  results:
+  - task:
+      type: {task_type}                                 # Required. Example: image-classification.
+      name: {task_name}                                 # Optional. Example: Image Classification.
+    dataset:
+      type: {dataset_type}                              # Required. Example: common_voice. Link to a repository containing the dataset or a dataset id from https://hf.co/datasets.
+      name: {dataset_name}                              # Required. Example: "Common Voice (French)". A pretty name for the dataset.
+      revision: {dataset_version}                       # Optional. Example: 5503434ddd753f426f4b38109466949a1217c2bb
+    metrics:
+    - type: {metric_type}                               # Required. Example: false-positive-rate. Use metric id from https://hf.co/metrics.
+      name: {metric_name}                               # Required. Example: "FPR wrt class 0 restricted to feature gender:0 and age:21".
+      value: {metric_value}                             # Required. Example: 0.75.
+      class: {metric_output_class}                      # Optional. Example: "1". Only relevant for certain metrics such as for example false-positive-rate positive rate.
+      subgroups:
+        - feature: {feature_name}                       # Optional. Example: "gender".
+          group: {feature_subgroup}                     # Optional. Example: "female".
+    measurements:
+      # Bar plots should be able to capture SHAP and Robustness Toolbox from AI Verify.
+      bar_plots:
+      - type: {measurement_type}                        # Required. Example: "SHAP".
+        name: {measurement_name}                        # Optional. Example: "Mean Absoulte Shap Values".
+        results:
+        - name: {bar_name}                              # Required. The name of a bar.
+          value: {bar_value}                            # Required. The corresponding value.
+      # Graph plots should be able to capture graph based measurements such as partial dependence and accumalated local effect.
+      graph_plots:
+      - type: {measurement_type}                        # Required. Example: "partial_dependence".
+        name: {measurement_name}                        # Optional. Example: "Partial Dependence Plot".
+        # Results store the graph plot data. So far all plots are depenendend on a combination of a specific class (sometimes) and feature (always).
+        # For example partial dependence plots are made for each feature and class.
+        results:
+         - class: {class_name}                          # Optional. Name of the output class the graph depends on.
+           feature: {feature_name}                      # Required. Name of the feature the graph depends on.
+           data:
+            - x_value: {x_value}                        # Required. The x value of the graph data.
+              y_value: {y_value}                        # Required. The y value of the graph data.
+
+# Assessments like IAMA.
+assessments:
+- name: {assessment_name}                               # Required. Example: IAMA.
+  date: {assessment_date}                               # Required. Example: 25-03-2025.
+  contents:
+    - question: {question_text}                         # Required. Example: "Question 1: ...".
+      answer: {answer_text}                             # Required. Example: "Answer: ...".
+      remarks: {remarks_text}                           # Optional. Example: "Remarks: ...".
+      authors:                                          # Optional. Example: "['John', 'Peter']".
+        - name: {author_name}
+      timestamp: {timestamp}                            # Optional. Example: 1711630721.
+```
+
+## Schema
+
+```json
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$id": "/tad_schema.json",
+    "$ref": "/definitions/TadSchema",
+    "title": "TadSchema",
+    "description": "A schema for the TAD reporting standard",  
+    "definitions": {
+        "TadSchema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "algorithm-registers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "language": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "licence": {
+                    "type": "string"
+                    "enum": ["apache-2.0", "mit", "openrail", "bigscience-openrail-m", "creativeml-openrail-m", "bigscience-bloom-rail-1.0", "bigcode-openrail-m", "afl-3.0", "artistic-2.0", "bsl-1.0", "bsd", "bsd-2-clause", "bsd-3-clause", "bsd-3-clause-clear", "c-uda", "cc", "cc0-1.0", "cc-by-2.0", "cc-by-2.5", "cc-by-3.0", "cc-by-4.0", "cc-by-sa-3.0", "cc-by-sa-4.0", "cc-by-nc-2.0", "cc-by-nc-3.0", "cc-by-nc-4.0", "cc-by-nd-4.0", "cc-by-nc-nd-3.0", "cc-by-nc-nd-4.0", "cc-by-nc-sa-2.0", "cc-by-nc-sa-3.0", "cc-by-nc-sa-4.0", "cdla-sharing-1.0", "cdla-permissive-1.0", "cdla-permissive-2.0", "wtfpl", "ecl-2.0", "epl-1.0", "epl-2.0", "etalab-2.0", "eupl-1.1", "agpl-3.0", "gfdl", "gpl", "gpl-2.0", "gpl-3.0", "lgpl", "lgpl-2.1", "lgpl-3.0", "isc", "lppl-1.3c", "ms-pl", "mpl-2.0", "odc-by", "odbl", "openrail++", "osl-3.0", "postgresql", "ofl-1.1", "ncsa", "unlicense", "zlib", "pddl", "lgpl-lr", "deepfloyd-if-license", "llama2", "gemma", "unknown", "other"]
+                },
+                "license_name": {
+                    "type": "string"
+                },
+                "license_link": {
+                    "type": "string"
+                },
+                "library_name": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "upl": {
+                    "type": "string"
+                },
+                "owners": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Owner"
+                    }
+                },
+                "model-index": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ModelIndex"
+                    }
+                },
+                "assessments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Assessment"
+                    }
+                }
+            },
+            "required": [
+                "assessments",
+                "licence",
+                "model-index",
+                "owners"
+            ]
+        },
+        "Assessment": {
+            "title": "Assessment",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "contents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Content"
+                    }
+                }
+            },
+            "required": [
+                "date",
+                "name",
+                "contents"
+            ],
+        },
+        "Content": {
+            "title": "Content",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "question": {
+                    "type": "string"
+                },
+                "answer": {
+                    "type": "string"
+                },
+                "remarks": {
+                    "type": "string"
+                },
+                "authors": {
+                    "$ref": "#/definitions/Authors"
+                },
+                "timestamp": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "question",
+                "answer"
+            ]
+        },
+        "Authors": {
+            "title": "Authors",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "ModelIndex": {
+            "title": "ModelIndex",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ModelIndexResult"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "results"
+            ]
+        },
+        "ModelIndexResult": {
+            "title": "ModelIndexResult",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "task": {
+                    "$ref": "#/definitions/Task"
+                },
+                "dataset": {
+                    "$ref": "#/definitions/Dataset"
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Metric"
+                    }
+                },
+                "measurements": {
+                    "$ref": "#/definitions/Measurements"
+                }
+            },
+            "required": [
+                "dataset",
+                "metrics",
+                "task"
+            ]
+        },
+        "Dataset": {
+            "title": "Dataset",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "revision": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "name"
+            ]
+        },
+        "Measurements": {
+            "title": "Measurements",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bar_plots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BarPlot"
+                    }
+                },
+                "graph_plots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GraphPlot"
+                    }
+                }
+            }
+        },
+        "BarPlot": {
+            "title": "BarPlot",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BarPlotResult"
+                    }
+                }
+            },
+            "required": [
+                "type",
+                "results"
+            ]
+        },
+        "BarPlotResult": {
+            "title": "BarPlotResult",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ]
+        },
+        "GraphPlot": {
+            "title": "GraphPlot",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GraphPlotResult"
+                    }
+                }
+            },
+            "required": [
+                "type",
+                "results"
+            ]
+        },
+        "GraphPlotResult": {
+            "title": "GraphPlotResult",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "class": {
+                    "type": "string"
+                },
+                "feature": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "x_value": {
+                                    "type": "number"
+                                },
+                                "y_value": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "x_value",
+                                "y_value"
+                            ]
+                        }
+                }
+            },
+            "required": [
+                "feature",
+                "data"
+            ]
+        },
+
+        "Metric": {
+            "title": "Metric",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number"
+                },
+                "class": {
+                    "type": "string"
+                },
+                "subgroups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Subgroup"
+                    }
+                }
+            },
+            "required": [
+                "type",
+                "name",
+                "value"
+            ]
+        },
+        "Subgroup": {
+            "title": "Subgroup",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "feature": {
+                    "type": "string"
+                },
+                "group": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "feature",
+                "group"
+            ]
+        },
+        "Task": {
+            "title": "Task",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "Owner": {
+            "title": "Owner",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "organization": {
+                    "type": "string"
+                },
+                "oin": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "organization"
+            ]
+        }
+    }
+}
+```
+
+[^1]: Deviation from the HuggingFace specification is in the Dataset Type field. HuggingFace only accepts
+dataset id's from [HuggingFace datasets](https://hf.co/datasets) while we also allow for any url pointing to the dataset.
+
+[^2]: For this extension to work relevent metrics (such as for example false positive rate) have to be added to the
+[Hugging Face metrics](https://hf.co//metrics), possibly this can be done in our organizational namespace.

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -58,9 +58,9 @@ A `system_card` contains the following information.
 
 #### 2. Models
 
-1. `models` (OPTIONAL, list[ModelCard]). A list of model cards (as defined below) or `!include`s of a yaml file containing a model card. This model card can for example be a model
-card described in the next section or a model card from Hugging Face. There can be multiple model cards, meaning multiple
-models are used.
+1. `models` (OPTIONAL, list[ModelCard]). A list of model cards (as defined below) or `!include`s of a yaml
+file containing a model card. This model card can for example be a model card described in the next section
+or a model card from Hugging Face. There can be multiple model cards, meaning multiple models are used.
 
 #### 3. Assessments
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -1,10 +1,15 @@
 # TAD Reporting Standard
 
-This document describes the Transparancy of Algorithmic Decision Making (TAD) reporting standard.
+This document describes the Transparancy of Algorithmic Decision Making (TAD) reporting standard. Assessing
+fairness and bias in Machine Learning models can be done through various technical tests, but also by answering
+regulatory assessments. The goal of this reporting standard is to capture these technical tests and assessments
+in a standardised way.
 
 ## Introduction
 
-The standard almost [^1] [^2] extends the [Hugging Face model card metadata specification](https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1)
+Inspired by [Papers with Code Model Index](https://github.com/paperswithcode/model-index) and
+[Model Cards for Model Reporting](https://arxiv.org/abs/1810.03993) this standard almost [^1] [^2] [^3] [^4]
+extends the [Hugging Face model card metadata specification](https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1)
 to allow for:
 
 1. More finegrained information on performance metrics, by extending the `metrics_field` from the Hugging
@@ -12,16 +17,23 @@ Face metadata specification.
 2. Capturing additional *measurements* on fairness and bias, which can be partitioned into bar plot like
 measurements (such as mean absolute SHAP values) and graph plot like measurements (such as partial dependence). This is achieved
 by defining an new field `measurements`.
-3. Capturing *assessments* (such as IAMA). This is achieved by defining a new field `assessments`.
+3. Capturing *assessments* (such as [IAMA](https://www.rijksoverheid.nl/documenten/rapporten/2021/02/25/impact-assessment-mensenrechten-en-algoritmes)
+and [ALTAI](https://digital-strategy.ec.europa.eu/en/library/assessment-list-trustworthy-artificial-intelligence-altai-self-assessment)).
+This is achieved by defining a new field `assessments`.
 
 This standard does not contain all fields present in the Hugging Face metadata specification. The fields that
 are optional in the HuggingFace specification AND are specific to the HugginFace interface are ommited.
 
 Following Hugging Face, this proposed standard will be written in yaml.
 
+Another difference is that we devide our implementation into two parts.
+
+1. `systems card`, containing information about a group of ML-models which accomplish a specific task.
+2. `model card`, containing information about a specific ML-model.
+
 ## Intended usage
 
-The reporting standard defined in this document is intented to be given as a preamble in a model card, similar to
+The reporting standard defined in this document is intented to be given as a preamble in a README, similar to
 the Hugging Face metadata.
 
 ## Specification of the standard
@@ -29,24 +41,13 @@ the Hugging Face metadata.
 The standard will be written in yaml. An example yaml is given in the next section. The standard contains the
 following information.
 
-1. `algorithm-registers` (OPTIONAL, list[string]). If this algorithm is registered in an algorithm register,
-this field should contain a URI to the corresponding record in the register. There can be multiple registers.
-A URI could look like `https://huggingface.co/org/modelid` or `https://algoritmes.overheid.nl/nl/algoritme/modelid`.
-2. `language` (OPTIONAL, list[string]). If relevant, the natural languages the model supports in ISO 639.
-    There can be multiple languages.
-3. `license`(REQUIRED, string). Any license from the [license list](https://huggingface.co/docs/hub/repositories-licenses).
-If the license is NOT present in the license list this field must be set to 'other' and the following two fields will
-be REQUIRED.
+### `system_card`
 
-    1. `license_name` (string). An id for the license.
-    2. `license_link` (string). A link to a file of that name inside the repo, or a URL to a remote file containing the license
-    contents.
+A `system_card` contains the following information.
 
-4. `library` (OPTIONAL, string). Any library from the [library list](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts).
-5. `tags` (OPTIONAL, list[string]). Tags with keywords to describe the project. There can be multiple tags.
-6. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
+1. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
     it should contain a URI from the [Uniform Product List](https://standaarden.overheid.nl/owms/oquery/UPL-actueel.plain).
-7. `owners` (list). There can be multiple owners. For each owner the following fields are present.
+2. `owners` (list). There can be multiple owners. For each owner the following fields are present.
 
     1. `organization` (REQUIRED, string). Name of the organization that owns the model.
     2. `oin` (OPTIONAL, string). If applicable the [Organisatie-identificatienummer (OIN)](https://www.logius.nl/domeinen/toegang/organisatie-identificatienummer/wat-is-het).
@@ -55,43 +56,101 @@ be REQUIRED.
     5. `role` (OPTIONAL, string). Role of the contact person. This field should only be set when the `name` field
     is set.
 
+#### 2. Models
+
+1. `models` (OPTIONAL, list[string]). A URI to a yaml file containg a model card. This model card can for example be a model
+card described in the next section or a model card from Hugging Face. There can be multiple model cards, meaning multiple
+models are used.
+
+#### 3. Assessments
+
+There can be multiple assessments. For each assessment the following fields are present:
+
+1. `name` (REQUIRED). The name of the assessment.
+2. `date` (REQUIRED). The date at which the assessment is completed.
+3. `contents`. There can be multiple items in contents. For each item the following fields are present:
+
+    1. `question` (REQUIRED). A question.
+    2. `answer` (REQUIRED). An answer.
+    3. `remarks` (OPTIONAL). A field to put relevant discussion remarks in.
+    4. `authors`. There can be multiple names. For each name the following field is present.
+        1. `name` (OPTIONAL). The name of the author of the question.
+    5. `timestamp` (OPTIONAL). A timestamp of the date and time of the answer.
+
+### `model_card`
+
+A `model_card` contains the following information.
+
+1. `algorithm-registers` (OPTIONAL, list[string]). If this algorithm is registered in an algorithm register,
+this field should contain a URI to the corresponding record in the register. There can be multiple registers.
+A URI could look like `https://huggingface.co/org/modelid` or `https://algoritmes.overheid.nl/nl/algoritme/modelid`.
+2. `language` (OPTIONAL, list[string]). If relevant, the natural languages the model supports in [ISO 639](https://www.iso.org/iso-639-language-code).
+    There can be multiple languages.
+3. `license`(REQUIRED, string). Any license from the [open source license list](https://opensource.org/license)
+[^1]. If the license is NOT present in the license list this field must be set to 'other' and the following
+two fields will be REQUIRED.
+
+    1. `license_name` (string). An id for the license.
+    2. `license_link` (string). A link to a file of that name inside the repo, or a URL to a remote file containing the license
+    contents.
+
+4. `library_name` (OPTIONAL, string). Any library from the [library list](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts).
+    If the library is NOT present in the library list, the following fields CAN be set.
+    1. `library` (OPTIONAL, string). If a library is used that is not in the above list, you can provide
+    the name of the library used here.
+    2. `library_link` (OPTIONAL, string). If a libary is used that is not in the above list, you can
+    provide a URI to the repo of the library used here.
+5. `tags` (OPTIONAL, list[string]). Tags with keywords to describe the project. There can be multiple tags.
+
 ### 2. `model_index`
 
 There can be multiple models. For each model the following fields are present.
 
 1. `name` (REQUIRED, string). The name of the model.
 2. `model` (REQUIRED, string). A URI pointing to a repository containing the model file.
-3. `results` (list). There can be multiple results. For each result the following fields are present.
+3. `artifacts` (OPTIONAL, list[string]). A list of URI's where each URI refers to a relevant model
+artifact, that cannot be captured by any other field, but are relevant to model.
+4. `parameters` (list). There can be multiple parameters. For each parameter the following fields are present.
+
+    1. `name` (REQUIRED, string). The name of the parameter, for example "epochs".
+    2. `dtype` (OPTIONAL, string). The datatype of the parameter, for example "int".
+    3. `value` (OPTIONAL, string). The value of the parameter, for example 100.
+
+5. `results` (list). There can be multiple results. For each result the following fields are present.
 
     1. `task` (list).
 
         1. `task_type` (REQUIRED, string). The task of the model, for example "object-classifcation".
         2. `task_name` (OPTIONAL, string). A pretty name fo the model taks, for example "Object Classification".
 
-    2. `dataset` (list).
+    2. `dataset` (list). There can be multiple results [^2]. For each result the following fields are present.
 
         1. `type` (REQUIRED, string). The type of the dataset, can be a dataset id from [HuggingFace datasets](https://hf.co/datasets)
-        or a link to a repository containing the dataset[^1], for example "common_voice".
+        or any other link to a repository containing the dataset[^3], for example "common_voice".
         2. `name` (REQUIRED, string). Name pretty name for the dataset, for example "Common Voice (French)".
         3. `split` (OPTIONAL, string). The split of the dataset, for example "train".
-        4. `revision` (OPTIONAL, string). Version of the dataset, for example 5503434ddd753f426f4b38109466949a1217c2bb.
+        4. `features` (OPTIONAL, list[string]). List of feature names.
+        5. `revision` (OPTIONAL, string). Version of the dataset, for example 5503434ddd753f426f4b38109466949a1217c2bb.
 
     3. `metrics` (list). There can be multiple metrics. For each metric the following fields are present.
 
-        1. `type` (REQUIRED, string). A metric-id from [Hugging Face metrics](https://hf.co//metrics)[^2], for example accuracy.
+        1. `type` (REQUIRED, string). A metric-id from [Hugging Face metrics](https://hf.co//metrics)[^4], for example accuracy.
         2. `name` (REQUIRED, string). A descriptive name of the metric. For example "false positive rate" is
         not a descriptive name, but "training false positive rate w.r.t class x" is.
-        3. `value` (REQUIRED, float). The value of the metric.
-        4. `class` (OPTIONAL, string/int/float/bool). Some metrics (such as false positive rate for multiclass classification)
+        3. `dtype` (REQUIRED, string). The data type of the metric, for example `float`.
+        4. `value` (REQUIRED, float). The value of the metric.
+        5. `class` (OPTIONAL, string/int/float/bool). Some metrics (such as false positive rate for multiclass classification)
         depend on a specific output class. In this field the output class can be specified. It must only be set for metrics
         for which it makes sense.
-        5. `subgroups` (list). Metrics can be computed on subgroups of specific features. For example one can compute the
-        accuracy for examples where the feature "gender" is set to "male".
+        6. `labels` (list). Metrics can be computed for example on subgroups of specific features.
+        For example one can compute the accuracy for examples where the feature "gender" is set to "male".
         There can be multiple subgroups, which means that the metric is computed on the intersection of those subgroups.
         For each subgroup the following fields are present.
 
-            1. `feature` (OPTIONAL, string). The name of the feature. For example: "gender".
-            2. `group` (OPTIONAL, string). The value of the feature. If `feature` is set, this field must be set as wel.
+            1. `name` (OPTIONAL, string). The name of the feature. For example: "gender".
+            2. `type` (OPTIONAL, string). The datatype of the feature, for example `float`. If `name` is set, this field
+            must be set as well.
+            3. `value` (OPTIONAL, string). The value of the feature. If `name` is set, this field must be set as wel.
             For example: "male".
 
     4. `measurements`.
@@ -122,36 +181,52 @@ There can be multiple models. For each model the following fields are present.
                     1. `x_value` (REQUIRED, float). The $x$-value of the graph.
                     2. `y_value` (REQUIRED, float). The $y$-value of the graph.
 
-### 3. Assessments
-
-There can be multiple assessments. For each assessment the following fields are present:
-
-1. `name` (REQUIRED). The name of the assessment.
-2. `date` (REQUIRED). The date at which the assessment is completed.
-3. `contents`. There can be multiple items in contents. For each item the following fields are present:
-
-    1. `question` (REQUIRED). A question.
-    2. `answer` (REQUIRED). An answer.
-    3. `remarks` (OPTIONAL). A field to put relevant discussion remarks in.
-    4. `authors`. There can be multiple names. For each name the following field is present.
-        1. `name` (OPTIONAL). The name of the author of the question.
-    5. `timestamp` (OPTIONAL). A timestamp of the date and time of the answer.
-
 ## Example
+
+### System Card
+
+```yaml
+upl: {upl_uri}                                          # Optional. Example: https://standaarden.overheid.nl/owms/terms/AangifteVertrekBuitenland
+owners:
+- organization: {organization_name}                     # Required. Example: BZK
+  oin: {oin}                                            # Optional. Example: 00000001003214345000
+  name: {owner_name}                                    # Optional. Example: John Doe
+  email: {owner_email}                                  # Optional. Example: johndoe@email.com
+  role: {owner_role}                                    # Optional. Example: Data Scientist.
+
+# Model Cards
+models:
+ - !include {model_card_uri}                            # Optional. Example: model_card.yaml.
+
+# Assessments like IAMA.
+assessments:
+- name: {assessment_name}                               # Required. Example: IAMA.
+  date: {assessment_date}                               # Required. Example: 25-03-2025.
+  contents:
+    - question: {question_text}                         # Required. Example: "Question 1: ...".
+      answer: {answer_text}                             # Required. Example: "Answer: ...".
+      remarks: {remarks_text}                           # Optional. Example: "Remarks: ...".
+      authors:                                          # Optional. Example: "['John', 'Peter']".
+        - name: {author_name}
+      timestamp: {timestamp}                            # Optional. Example: 1711630721.
+```
+
+### Model Card
 
 ```yaml
 algorithm-registers:
   - {id}                                                # Optional. Example: https://algoritmes.overheid.nl/nl/algoritme/45991543.
 language:
   - {lang_0}                                            # Optional. Example nl.
-license: {licence}                                      # Required. Example: apache-2.0 or any license identifier from https://huggingface.co/docs/hub/repositories-licenses
+license: {licence}                                      # Required. Example: Apache-2.0 or any license SPDX ID from https://opensource.org/license or "other".
 license_name: {licence_name}                            # Required. if license = other, specify an id for the licence. Example: 'my-license-1.0'
 license_link: {license_link}                            # Required. if license = other, specify "LICENSE" or "LICENSE.md" to link to a file of that name inside the repo, or a URL to a remote file.
 library_name: {library_name}                            # Optional. Example: keras or any library from https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts.
+library: {library_name}                                 # Optional. Example: mylibrary
+library_link: {library_link}                            # Optional. URI to user provided library.
 tags:
 - {tag_0}                                               # Optional. Example: audio
 - {tag_1}                                               # Optional. Example: automatic-speech-recognition
-upl: {upl_uri}                                          # Optional. Example: https://standaarden.overheid.nl/owms/terms/AangifteVertrekBuitenland
 owners:
 - organization: {organization_name}                     # Required. Example: BZK
   oin: {oin}                                            # Optional. Example: 00000001003214345000
@@ -162,27 +237,38 @@ owners:
 model-index:
 - name: {model_id}                                      # Required. Example: CatClassifier.
   model: {model_uri}                                    # Required. URI to a repository containing the model file.
+  artifacs:
+  - {model_artifact}                                    # Optional. URI to relevant model artifacts, if applicable.
+  parameters:
+  - name: {parameter_name}                              # Optional. Example: "epochs".
+    dtype: {parameter_dtype}                            # Optional. Example "int".
+    value: {parameter_value}                            # Optional. Example 100.
   results:
   - task:
       type: {task_type}                                 # Required. Example: image-classification.
       name: {task_name}                                 # Optional. Example: Image Classification.
     dataset:
-      type: {dataset_type}                              # Required. Example: common_voice. Link to a repository containing the dataset or a dataset id from https://hf.co/datasets.
-      name: {dataset_name}                              # Required. Example: "Common Voice (French)". A pretty name for the dataset.
-      revision: {dataset_version}                       # Optional. Example: 5503434ddd753f426f4b38109466949a1217c2bb
+      - type: {dataset_type}                            # Required. Example: common_voice. Link to a repository containing the dataset
+        name: {dataset_name}                            # Required. Example: "Common Voice (French)". A pretty name for the dataset.
+        split: {split}                                  # Optional. Example "train".
+        features:
+         - {feature_name}                               # Optional. Example: "gender".
+        revision: {dataset_version}                     # Optional. Example: 5503434ddd753f426f4b38109466949a1217c2bb
     metrics:
     - type: {metric_type}                               # Required. Example: false-positive-rate. Use metric id from https://hf.co/metrics.
       name: {metric_name}                               # Required. Example: "FPR wrt class 0 restricted to feature gender:0 and age:21".
+      dtype: {metric_dtype}                             # Required. Example: "float".
       value: {metric_value}                             # Required. Example: 0.75.
       class: {metric_output_class}                      # Optional. Example: "1". Only relevant for certain metrics such as for example false-positive-rate positive rate.
-      subgroups:
-        - feature: {feature_name}                       # Optional. Example: "gender".
-          group: {feature_subgroup}                     # Optional. Example: "female".
+      labels:
+        - name: {feature_name}                          # Optional. Example: "gender".
+          type: {feature_type}                          # Optional. Example: "string".
+          value: {feature_value}                        # Optional. Example: "female".
     measurements:
       # Bar plots should be able to capture SHAP and Robustness Toolbox from AI Verify.
       bar_plots:
       - type: {measurement_type}                        # Required. Example: "SHAP".
-        name: {measurement_name}                        # Optional. Example: "Mean Absoulte Shap Values".
+        name: {measurement_name}                        # Optional. Example: "Mean Absolute Shap Values".
         results:
         - name: {bar_name}                              # Required. The name of a bar.
           value: {bar_value}                            # Required. The corresponding value.
@@ -199,442 +285,21 @@ model-index:
             - x_value: {x_value}                        # Required. The x value of the graph data.
               y_value: {y_value}                        # Required. The y value of the graph data.
 
-# Assessments like IAMA.
-assessments:
-- name: {assessment_name}                               # Required. Example: IAMA.
-  date: {assessment_date}                               # Required. Example: 25-03-2025.
-  contents:
-    - question: {question_text}                         # Required. Example: "Question 1: ...".
-      answer: {answer_text}                             # Required. Example: "Answer: ...".
-      remarks: {remarks_text}                           # Optional. Example: "Remarks: ...".
-      authors:                                          # Optional. Example: "['John', 'Peter']".
-        - name: {author_name}
-      timestamp: {timestamp}                            # Optional. Example: 1711630721.
 ```
 
 ## Schema
 
-```json
-{
-    "$schema": "http://json-schema.org/draft/2020-12/schema",
-    "$id": "/tad_schema.json",
-    "$ref": "/definitions/TadSchema",
-    "title": "TadSchema",
-    "description": "A schema for the TAD reporting standard",  
-    "definitions": {
-        "TadSchema": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "algorithm-registers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "language": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "licence": {
-                    "type": "string"
-                    "enum": ["apache-2.0", "mit", "openrail", "bigscience-openrail-m", "creativeml-openrail-m", "bigscience-bloom-rail-1.0", "bigcode-openrail-m", "afl-3.0", "artistic-2.0", "bsl-1.0", "bsd", "bsd-2-clause", "bsd-3-clause", "bsd-3-clause-clear", "c-uda", "cc", "cc0-1.0", "cc-by-2.0", "cc-by-2.5", "cc-by-3.0", "cc-by-4.0", "cc-by-sa-3.0", "cc-by-sa-4.0", "cc-by-nc-2.0", "cc-by-nc-3.0", "cc-by-nc-4.0", "cc-by-nd-4.0", "cc-by-nc-nd-3.0", "cc-by-nc-nd-4.0", "cc-by-nc-sa-2.0", "cc-by-nc-sa-3.0", "cc-by-nc-sa-4.0", "cdla-sharing-1.0", "cdla-permissive-1.0", "cdla-permissive-2.0", "wtfpl", "ecl-2.0", "epl-1.0", "epl-2.0", "etalab-2.0", "eupl-1.1", "agpl-3.0", "gfdl", "gpl", "gpl-2.0", "gpl-3.0", "lgpl", "lgpl-2.1", "lgpl-3.0", "isc", "lppl-1.3c", "ms-pl", "mpl-2.0", "odc-by", "odbl", "openrail++", "osl-3.0", "postgresql", "ofl-1.1", "ncsa", "unlicense", "zlib", "pddl", "lgpl-lr", "deepfloyd-if-license", "llama2", "gemma", "unknown", "other"]
-                },
-                "license_name": {
-                    "type": "string"
-                },
-                "license_link": {
-                    "type": "string"
-                },
-                "library_name": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "upl": {
-                    "type": "string"
-                },
-                "owners": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Owner"
-                    }
-                },
-                "model-index": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ModelIndex"
-                    }
-                },
-                "assessments": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Assessment"
-                    }
-                }
-            },
-            "required": [
-                "assessments",
-                "licence",
-                "model-index",
-                "owners"
-            ]
-        },
-        "Assessment": {
-            "title": "Assessment",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "contents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Content"
-                    }
-                }
-            },
-            "required": [
-                "date",
-                "name",
-                "contents"
-            ],
-        },
-        "Content": {
-            "title": "Content",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "question": {
-                    "type": "string"
-                },
-                "answer": {
-                    "type": "string"
-                },
-                "remarks": {
-                    "type": "string"
-                },
-                "authors": {
-                    "$ref": "#/definitions/Authors"
-                },
-                "timestamp": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "question",
-                "answer"
-            ]
-        },
-        "Authors": {
-            "title": "Authors",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "ModelIndex": {
-            "title": "ModelIndex",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "results": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ModelIndexResult"
-                    }
-                }
-            },
-            "required": [
-                "name",
-                "results"
-            ]
-        },
-        "ModelIndexResult": {
-            "title": "ModelIndexResult",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "task": {
-                    "$ref": "#/definitions/Task"
-                },
-                "dataset": {
-                    "$ref": "#/definitions/Dataset"
-                },
-                "metrics": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Metric"
-                    }
-                },
-                "measurements": {
-                    "$ref": "#/definitions/Measurements"
-                }
-            },
-            "required": [
-                "dataset",
-                "metrics",
-                "task"
-            ]
-        },
-        "Dataset": {
-            "title": "Dataset",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "revision": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type",
-                "name"
-            ]
-        },
-        "Measurements": {
-            "title": "Measurements",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "bar_plots": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/BarPlot"
-                    }
-                },
-                "graph_plots": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/GraphPlot"
-                    }
-                }
-            }
-        },
-        "BarPlot": {
-            "title": "BarPlot",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "results": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/BarPlotResult"
-                    }
-                }
-            },
-            "required": [
-                "type",
-                "results"
-            ]
-        },
-        "BarPlotResult": {
-            "title": "BarPlotResult",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "number"
-                }
-            },
-            "required": [
-                "name",
-                "value"
-            ]
-        },
-        "GraphPlot": {
-            "title": "GraphPlot",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "results": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/GraphPlotResult"
-                    }
-                }
-            },
-            "required": [
-                "type",
-                "results"
-            ]
-        },
-        "GraphPlotResult": {
-            "title": "GraphPlotResult",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "class": {
-                    "type": "string"
-                },
-                "feature": {
-                    "type": "string"
-                },
-                "data": {
-                    "type": "array",
-                    "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "x_value": {
-                                    "type": "number"
-                                },
-                                "y_value": {
-                                    "type": "number"
-                                }
-                            },
-                            "required": [
-                                "x_value",
-                                "y_value"
-                            ]
-                        }
-                }
-            },
-            "required": [
-                "feature",
-                "data"
-            ]
-        },
+JSON schema will be added here.
 
-        "Metric": {
-            "title": "Metric",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "number"
-                },
-                "class": {
-                    "type": "string"
-                },
-                "subgroups": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Subgroup"
-                    }
-                }
-            },
-            "required": [
-                "type",
-                "name",
-                "value"
-            ]
-        },
-        "Subgroup": {
-            "title": "Subgroup",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "feature": {
-                    "type": "string"
-                },
-                "group": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "feature",
-                "group"
-            ]
-        },
-        "Task": {
-            "title": "Task",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ]
-        },
-        "Owner": {
-            "title": "Owner",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "organization": {
-                    "type": "string"
-                },
-                "oin": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "organization"
-            ]
-        }
-    }
-}
-```
+[^1]: Deviation from the HuggingFace specification is in the Licence field. HuggingFace only accepts
+dataset id's from [HuggingFace license list](https://huggingface.co/docs/hub/repositories-licenses) while we
+accept any license from [Open Source License List](https://opensource.org/license).
 
-[^1]: Deviation from the HuggingFace specification is in the Dataset Type field. HuggingFace only accepts
+[^2]: Deviation from the HuggingFace specification is in the `model_index:results:dataset` field. HuggingFace only accepts
+one dataset, while we accept a list of datasets.
+
+[^3]: Deviation from the HuggingFace specification is in the Dataset Type field. HuggingFace only accepts
 dataset id's from [HuggingFace datasets](https://hf.co/datasets) while we also allow for any url pointing to the dataset.
 
-[^2]: For this extension to work relevent metrics (such as for example false positive rate) have to be added to the
+[^4]: For this extension to work relevent metrics (such as for example false positive rate) have to be added to the
 [Hugging Face metrics](https://hf.co//metrics), possibly this can be done in our organizational namespace.

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -387,7 +387,7 @@ contents:
 
 ## Schema
 
-JSON schema will be added here.
+JSON schema will be added when we publish the first beta version.
 
 [^1]: Deviation from the HuggingFace specification is in the Licence field. HuggingFace only accepts
 dataset id's from [HuggingFace license list](https://huggingface.co/docs/hub/repositories-licenses) while we

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -45,9 +45,9 @@ Another difference is that we devide our implementation into three seperate part
 !!! note "Include statements"
 
     These `model_card`s and  `assessment_card`s  can be included verbatim into a `system_card`,
-    or referenced with an `!include` statement, allowing for minimal cards to be compact and in a
-    single file, but for extensive cards to be split up for readability and maintainability.
-    Our standard allows for the `!include` to be used anywhere.
+    or referenced with an `!include` statement, allowing for minimal cards to be compact in a single
+    file. Extensive cards can be split up for readability and maintainability. Our standard allows for
+    the `!include` to be used anywhere.
 
 ## Specification of the standard
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -39,7 +39,7 @@ are optional in the HuggingFace specification and are specific to the HugginFace
 Another difference is that we devide our implementation into three seperate parts.
 
 1. `system_card`, containing information about a group of ML-models which accomplish a specific task.
-2. `model_card`, containing information about a specific ML-model.
+2. `model_card`, containing information about a specific data science model.
 3. `assessment_card`, containing information about a regulatory assessment.
 
 !!! note "Include statements"

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -1,9 +1,16 @@
 # TAD Reporting Standard
 
+Version 0.1
+
 This document describes the Transparancy of Algorithmic Decision Making (TAD) reporting standard. Assessing
 fairness and bias in Machine Learning models can be done through various technical tests, but also by answering
 regulatory assessments. The goal of this reporting standard is to capture these technical tests and assessments
 in a standardised way.
+
+## Disclaimer
+
+The TAD Reporting Standard is work in progress. This means that the current standard is probably suboptimal
+and will change significantly in future versions.
 
 ## Introduction
 
@@ -28,8 +35,8 @@ Following Hugging Face, this proposed standard will be written in yaml.
 
 Another difference is that we devide our implementation into two parts.
 
-1. `systems card`, containing information about a group of ML-models which accomplish a specific task.
-2. `model card`, containing information about a specific ML-model.
+1. `systems_card`, containing information about a group of ML-models which accomplish a specific task.
+2. `model_card`, containing information about a specific ML-model.
 
 ## Intended usage
 
@@ -38,8 +45,8 @@ the Hugging Face metadata.
 
 ## Specification of the standard
 
-The standard will be written in yaml. An example yaml is given in the next section. The standard contains the
-following information.
+The standard will be written in yaml. An example yaml is given in the next section. The standard defines
+two 'cards': a `system_card` and a `model_card`.
 
 ### `system_card`
 

--- a/docs/Projects/TAD/reporting_standard.md
+++ b/docs/Projects/TAD/reporting_standard.md
@@ -49,11 +49,6 @@ Another difference is that we devide our implementation into three seperate part
     single file, but for extensive cards to be split up for readability and maintainability.
     Our standard allows for the `!include` to be used anywhere.
 
-## Intended usage
-
-The reporting standard defined in this document is intented to be given as a preamble in a README, similar to
-the Hugging Face metadata.
-
 ## Specification of the standard
 
 The standard will be written in yaml. Example yaml files are given in the next section. The standard defines

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.superfences
+  - footnotes
   - pymdownx.details
   - admonition
   - attr_list


### PR DESCRIPTION
# TAD Reporting Standard

This PR contains the first version of the TAD reporting standard. 

Reading order suggestions:
- Read "introduction" and "intended usage"
- Read the YAML example
- Read the "specification of the standard"
- Read the JSON schema

Expected shortcomings:
- It is highly likely that we need to revise the standard to avoid very large yaml files. This explicitly has not been taken into account yet.
- It is highly likely that we need to revise the datatypes.
- It is highly likely that the way we capture measurements needs to be adjusted. 

The shortcomings will probably be exposed at the moment we will try to actually write an example output, at which point we can address them.