### PR TITLE
Adding the ADR for using English language as default for coding

### DIFF
--- a/aivalidation_dictionary.txt
+++ b/aivalidation_dictionary.txt
@@ -96,3 +96,7 @@ webex
 webserver
 Weijs
 Woudloper
+Algemene
+bestuursrecht
+wetten
+overheid

--- a/docs/adrs/0014-written-language.md
+++ b/docs/adrs/0014-written-language.md
@@ -1,0 +1,55 @@
+# ADR-0014 Written Language
+
+## Context
+
+In order to expand our reach and foster international collaboration in the field of AI Validation, we have decided to
+conduct all communication in English on public platforms such as GitHub. This decision aims to facilitate better
+understanding and participation from our global colleagues. However, within the Dutch Government, the norm is to
+communicate in Dutch for internal purposes. This ADR will provide  guidelines on which language to use for different
+types of communications.
+
+## Assumptions
+
+There is no requirement to use Dutch as the primary language for all our activities while working for the Dutch
+government. More information can be found in the [More Information](#more-information) section.
+
+## Decision
+
+The following channels will utilize English:
+
+- GitHub Projects
+- GitHub Repository
+- Email to International partners
+
+The primary language for the following channels will be Dutch:
+
+- Mattermost (Internal Collaboration tool)
+- Email to Internal parties
+- Official Internal Documents like memo's or notes to the chamber
+- Guides for Dutch Users on how to use the tools
+- UI for the tools we will make
+
+## Risks
+
+Dutch-only developers will have a harder time following along with the progression of our team on both the code on
+GitHub as our Project Management.
+
+## Consequences
+
+- All tickets and issues will be written in English on GitHub projects
+- The review on code will be written in English
+- Comments in the code and commit messages will be written in English
+- Guides on usage of the tools will be written in both Dutch and English
+
+## More Information
+
+Although many attempts by the previous cabinets, Dutch is not an official language in the Netherlands according to the
+Dutch constitution see the following
+[link](https://www.denederlandsegrondwet.nl/id/viivckl8ibxx/nederlandse_taal_in_de_grondwet).
+
+According to the [website of the central government](https://www.rijksoverheid.nl/onderwerpen/erkende-talen/vraag-en-antwoord/erkende-talen-nederland)
+the Dutch language is the official recognized language. Meaning in combination with the law `Algemene wet bestuursrecht`
+on [wetten.overheid.nl](https://wetten.overheid.nl/BWBR0005537/2024-01-01) that governing bodies and their employees
+needs to be communicating in Dutch unless stated differently elsewhere. And especially is stated
+[here](https://wetten.overheid.nl/jci1.3:c:BWBR0005537&hoofdstuk=2&afdeling=2.2&artikel=2:6&z=2024-01-01&g=2024-01-01)
+that can be deviated from it unless there is more efficient goal.

--- a/docs/adrs/0014-written-language.md
+++ b/docs/adrs/0014-written-language.md
@@ -4,29 +4,29 @@
 
 In order to expand our reach and foster international collaboration in the field of AI Validation, we have decided to
 conduct all communication in English on public platforms such as GitHub. This decision aims to facilitate better
-understanding and participation from our global colleagues. However, within the Dutch Government, the norm is to
-communicate in Dutch for internal purposes. This ADR will provide  guidelines on which language to use for different
-types of communications.
+understanding and participation from our global colleagues. However, within the Government of the Netherlands, the
+norm is to communicate in Dutch for internal purposes. This ADR will provide guidelines on which language to use for
+different types of communications.
 
 ## Assumptions
 
-There is no requirement to use Dutch as the primary language for all our activities while working for the Dutch
-government. More information can be found in the [More Information](#more-information) section.
+There is no requirement to use Dutch as the primary language for all our activities while working for the Government of
+the Netherlands. More information can be found in the [More Information](#more-information) section.
 
 ## Decision
 
 The following channels will utilize English:
 
-- GitHub Projects
-- GitHub Repository
-- Email to International partners
+- GitHub projects
+- GitHub repository
+- Email to international partners
 
 The primary language for the following channels will be Dutch:
 
-- Mattermost (Internal Collaboration tool)
-- Email to Internal parties
-- Official Internal Documents like memo's or notes to the chamber
-- Guides for Dutch Users on how to use the tools
+- Mattermost (internal collaboration tool)
+- Emails to internal parties
+- Official internal documents like memo's or notes to the house of representatives
+- Guides for Dutch users on how to use the tools
 - UI for the tools we will make
 
 ## Risks
@@ -36,20 +36,22 @@ GitHub as our Project Management.
 
 ## Consequences
 
-- All tickets and issues will be written in English on GitHub projects
-- The review on code will be written in English
-- Comments in the code and commit messages will be written in English
-- Guides on usage of the tools will be written in both Dutch and English
+- All tickets and issues will be written in English on GitHub projects.
+- Code reviews will be written in English.
+- Comments in the code and commit messages will be written in English.
+- Documentation of the tools will be written in both Dutch and English.
 
 ## More Information
 
-Although many attempts by the previous cabinets, Dutch is not an official language in the Netherlands according to the
-Dutch constitution see the following
+Although many attempts by previous cabinets, Dutch is not the official language in the Netherlands according to the
+Dutch constitution. See the following
 [link](https://www.denederlandsegrondwet.nl/id/viivckl8ibxx/nederlandse_taal_in_de_grondwet).
 
-According to the [website of the central government](https://www.rijksoverheid.nl/onderwerpen/erkende-talen/vraag-en-antwoord/erkende-talen-nederland)
-the Dutch language is the official recognized language. Meaning in combination with the law `Algemene wet bestuursrecht`
-on [wetten.overheid.nl](https://wetten.overheid.nl/BWBR0005537/2024-01-01) that governing bodies and their employees
-needs to be communicating in Dutch unless stated differently elsewhere. And especially is stated
+According to the [website of the Government of the Netherlands](https://www.rijksoverheid.nl/onderwerpen/erkende-talen/vraag-en-antwoord/erkende-talen-nederland)
+the Dutch language is the official recognized language. This means that in combination with the law `Algemene wet bestuursrecht`
+on [wetten.overheid.nl](https://wetten.overheid.nl/BWBR0005537/2024-01-01) governing bodies and their employees
+need to communicate in Dutch unless stated differently elsewhere. It is stated
 [here](https://wetten.overheid.nl/jci1.3:c:BWBR0005537&hoofdstuk=2&afdeling=2.2&artikel=2:6&z=2024-01-01&g=2024-01-01)
-that can be deviated from it unless there is more efficient goal.
+that communicating in another language than Dutch is permitted if the goal of communicating in another language than
+Dutch is sufficiently justified and if other parties are not effected disproportionately by the usage of another
+language.


### PR DESCRIPTION
# Description

Adding an ADR on which channels we use English and which channels we use Dutch

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilizes.

## Developer Certificate of Origin

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
