### PR TITLE
Add URN to assessment card

### DIFF
--- a/docs/projects/tad/reporting-standard/0.1a6.md
+++ b/docs/projects/tad/reporting-standard/0.1a6.md
@@ -1,4 +1,4 @@
-# :label: 0.1a7 (Latest)
+# :label: 0.1a6
 
 This document describes the Transparency of Algorithmic Decision making (TAD) Reporting Standard.
 
@@ -300,20 +300,18 @@ An `assessment_card` contains the following information.
     4. `author` (OPTIONAL, string). Name of person that initiated the transformations.
 
 2. `name` (REQUIRED, string). The name of the assessment.
-3. `urn` (OPTIONAL, string). A Uniform Resource Name (URN) of the instrument in the instrument register.
-4. `date` (REQUIRED, string). The date at which the assessment is completed. Date should be given in
+3. `date` (REQUIRED, string). The date at which the assessment is completed. Date should be given in
    [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `YYYY-MM-DD`.
-5. `contents` (REQUIRED, list). There can be multiple items in contents. For each item the following fields are present:
+4. `contents` (REQUIRED, list). There can be multiple items in contents. For each item the following fields are present:
 
     1. `question` (REQUIRED, string). A question.
-    2. `urn` (OPTIONAL, string). A Uniform Resource Name (URN) of the corresponding task in the instrument register.
-    3. `answer` (REQUIRED, string). An answer.
-    4. `remarks` (OPTIONAL, string). A field to put relevant discussion remarks in.
-    5. `authors` (OPTIONAL, list). There can be multiple names. For each name the following field is present.
+    2. `answer` (REQUIRED, string). An answer.
+    3. `remarks` (OPTIONAL, string). A field to put relevant discussion remarks in.
+    4. `authors` (OPTIONAL, list). There can be multiple names. For each name the following field is present.
 
         1. `name` (OPTIONAL, string). The name of the author of the question.
 
-    6. `timestamp` (OPTIONAL, string). A timestamp of the date, time and timezone of the answer. Timestamp should be
+    5. `timestamp` (OPTIONAL, string). A timestamp of the date, time and timezone of the answer. Timestamp should be
         given, preferably in UTC (represented as `Z`), in
         [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `2024-04-16T16:48:14Z`.
 
@@ -465,11 +463,9 @@ provenance:
   uri: {modification_uri}
   author: {modification_author}
 name: {assessment_name}
-urn: {urn}
 date: {assessment_date}
 contents:
   - question: {question_text}
-    urn: {urn}
     answer: {answer_text}
     remarks: {remarks_text}
     authors:
@@ -483,7 +479,6 @@ JSON schema will be added when we publish the first beta version.
 
 ## Changelog
 
-- 0.1a7: adds urn to assessment card
 - 0.1a6:
     - fix mismatches between description and examples
     - format YAML examples and Markdown formatting

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
       - Reporting Standard:
         - projects/tad/reporting-standard/index.md
         - projects/tad/reporting-standard/latest.md
+        - projects/tad/reporting-standard/0.1a6.md
         - projects/tad/reporting-standard/0.1a5.md
         - projects/tad/reporting-standard/0.1a4.md
         - projects/tad/reporting-standard/0.1a3.md


### PR DESCRIPTION
# Description

This adds a URN to the contents field of an assessment card. This is needed for the [TAD CLI ticket](https://github.com/orgs/MinBZK/projects/7/views/3?pane=issue) ticket.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilizes.

## Developer Certificate of Origin

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
