### PR TITLE
Proposal structure systemcard

### DIFF
--- a/docs/projects/amt/reporting-standard/0.1a11.md
+++ b/docs/projects/amt/reporting-standard/0.1a11.md
@@ -1,11 +1,11 @@
-# :label: 0.1a11 (Latest)
+# :label: 0.1a11
 
 This document describes the Algorithm Management Toolkit (AMT) Reporting Standard.
 
 For reproducibility, governance, auditing and sharing of algorithmic systems it is essential to have a reporting
 standard so that information about an algorithmic system can be shared. This reporting standard describes how
 information about the different phases of an algorithm's life cycle can be reported. It contains, among other things,
-descriptive information combined with information about the technical tests and tasks applied.
+descriptive information combined with information about the technical tests and assessments applied.
 
 !!! warning "Disclaimer"
 
@@ -25,10 +25,10 @@ to allow for:
 2. Capturing additional *measurements* on fairness and bias, which can be partitioned into bar plot like
    measurements (such as mean absolute SHAP values) and graph plot like measurements (such as partial dependence). This
    is achieved by defining a new field `measurements`.
-3. Capturing *tasks* or *tools* (such as
+3. Capturing *assessments* (such as
    [IAMA](https://www.rijksoverheid.nl/documenten/rapporten/2021/02/25/impact-assessment-mensenrechten-en-algoritmes)
    and [ALTAI](https://digital-strategy.ec.europa.eu/en/library/assessment-list-trustworthy-artificial-intelligence-altai-self-assessment)).
-   This is achieved by defining a new field `tasks`.
+   This is achieved by defining a new field `assessments`.
 
 Following Hugging Face, this proposed standard will be written in YAML.
 
@@ -39,20 +39,20 @@ Another difference is that we divide our implementation into three separate part
 
 1. `system_card`, containing information about a group of ML-models which accomplish a specific task.
 2. `model_card`, containing information about a specific data science model.
-3. `task_card`, containing information about a regulatory task.
+3. `assessment_card`, containing information about a regulatory assessment.
 
 !!! note "Include statements"
 
-    These `model_card`s and  `task_card`s  can be included verbatim into a `system_card`, or referenced with an
+    These `model_card`s and  `assessment_card`s  can be included verbatim into a `system_card`, or referenced with an
     `!include` statement, allowing for minimal cards to be compact in a single file. Extensive cards can be split up for
     readability and maintainability. Our standard allows for the `!include` to be used anywhere.
 
 ## Specification of the standard
 
 The standard will be written in YAML. Example YAML files are given in the next section. The standard defines three
-cards: a `system_card`, a `model_card` and an `task_card`. A `system_card` contains information about an
+cards: a `system_card`, a `model_card` and an `assessment_card`. A `system_card` contains information about an
 algorithmic system. It can have multiple models and each of these models should have a `model_card`. Regulatory
-tasks can be processed in an `task_card`. Note that `model_card`'s and `task_card`'s can be included
+assessments can be processed in an `assessment_card`. Note that `model_card`'s and `assessment_card`'s can be included
 directly into the `system_card` or can be included as separate YAML files with help of a YAML-include mechanism. For
 clarity the latter is preferred and is also used in the examples in the next section.
 
@@ -73,17 +73,14 @@ A `system_card` contains the following information.
     4. `author` (OPTIONAL, string). Name of person that initiated the transformations.
 
 3. `name` (OPTIONAL, string). Name used to describe the system.
+4. `instruments` (OPTIONAL, list). List of instruments from
+the [task registry](https://github.com/MinBZK/task-registry) that must be executed to fill this system card.
+There can be multiple instruments. For each instrument the following fields are present.
 
-4. `selected_tasks` (OPTIONAL, list). List of tasks from the [task registry](https://github.com/MinBZK/task-registry) that are selected to be performed categorized in requirements, measures and tools. 
-    1. `requirements`(OPTIONAL, list). List of selected requirements. 
-        1. `urn` (OPTIONAL, string). URN of the requirement.
-        2. `version` (OPTIONAL, string). Version of the task registry. 
-    2. `measures` (OPTIONAL, list). List of selected measures. 
-        1. `urn` (OPTIONAL, string). URN of the measures selected.
-        2. `version` (OPTIONAL, string). Version of the task registry. 
-    3. `tools`(OPTIONAL, list). List of selected tools. 
-        1. `urn` (OPTIONAL, string). URN of the tools selected.
-        2. `version` (OPTIONAL, string). Version of the task registry.
+    1. `urn` (REQUIRED, string). Uniform Resource Names of the instrument. It is required if an instrument object
+        is added.
+    2. `version` (OPTIONAL, string). The version of the instrument.
+    3. `required` (OPTIONAL, boolean). Specifies whether the instrument is required to be executed or not.
 
 5. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
     it should contain a URI from the
@@ -102,56 +99,92 @@ A `system_card` contains the following information.
 7. `description` (OPTIONAL, string). A short description of the system.
 8. `ai_act_profile` (OPTIONAL). Information about the system in relation to the EU AI Act.
     The contents of this field can be retrieved by traversing the AI Act decision tree or can be specified by the user.
-    1. `provenance` (OPTIONAL). This field can capture the context of the contents of the ai act profile labels. 
-        1. `git_commit_hash` (OPTIONAL, string). Git commit hash of the commit which contains the transformation file used
-            to create this card.
-        2. `timestamp` (OPTIONAL, string). A timestamp of the date, time and timezone of generation of this System Card.
-            Timestamp should be given, preferably in UTC (represented as `Z`), in
-            [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `2024-04-16T16:48:14Z`.
-        3. `uri` (OPTIONAL, string). URI to the tool that was used to perform the transformations.
-        4. `author` (OPTIONAL, string). Name of person that initiated the transformations.
 
-    2. `labels` (OPTIONAL, list). 
-
-        1. `type` (OPTIONAL, enum[string]). The type of the system should be chosen from:
-        `["AI-systeem", "AI-systeem voor algemene doeleinden", "AI-model voor algemene doeleinden", "geen algoritme"]`.
-        2. `open_source` (OPTIONAL, enum[string]). Whether the system is open source or not.
-        Options are `["open-source", "geen open-source"]`.
-        3. `publication_category` (OPTIONAL, enum[string]). The publication category of the system should be chosen from:
-        `["impactvol algoritme", "niet-impactvol algoritme",  "hoog-risico AI",
-        "geen hoog-risico AI", "verboden AI", "uitzondering van toepassing"]`.
-        4. `systemic_risk` (OPTIONAL, enum[string]). Whether the AI model is classified as having systemic risk.
-        Options are `["systeemrisico", "geen systeemrisico"]`.
-        5. `transparency_obligations` (OPTIONAL, enum[string]). Whether the system faces transparency obligations.
-        Options are `["transparantieverplichtingen", "geen transparantieverplichtingen"]`.
-        6. `role` (OPTIONAL, enum[string]). The organization’s role in relation to the system.
-        Options are `["aanbieder", "gebruiksverantwoordelijke", "aanbieder + gebruiksverantwoordelijke"]`
-    3. `decision_tree` (OPTIONAL). This field is REQUIRED if the above fields are retrieved by traversing the decision tree.
+    1. `type` (OPTIONAL, enum[string]). The type of the system should be chosen from:
+    `["AI-systeem", "AI-systeem voor algemene doeleinden", "AI-model voor algemene doeleinden", "geen algoritme"]`.
+    2. `open_source` (OPTIONAL, enum[string]). Whether the system is open source or not.
+    Options are `["open-source", "geen open-source"]`.
+    3. `publication_category` (OPTIONAL, enum[string]). The publication category of the system should be chosen from:
+    `["impactvol algoritme", "niet-impactvol algoritme",  "hoog-risico AI",
+    "geen hoog-risico AI", "verboden AI", "uitzondering van toepassing"]`.
+    4. `systemic_risk` (OPTIONAL, enum[string]). Whether the AI model is classified as having systemic risk.
+    Options are `["systeemrisico", "geen systeemrisico"]`.
+    5. `transparency_obligations` (OPTIONAL, enum[string]). Whether the system faces transparency obligations.
+    Options are `["transparantieverplichtingen", "geen transparantieverplichtingen"]`.
+    6. `role` (OPTIONAL, enum[string]). The organization’s role in relation to the system.
+    Options are `["aanbieder", "gebruiksverantwoordelijke", "aanbieder + gebruiksverantwoordelijke"]`
+    7. `decision_tree` (OPTIONAL). This field is REQUIRED if the above fields are retrieved by traversing the decision tree.
 
         1. `version` (REQUIRED, string). The version of the decision tree.
         2. `path` (REQUIRED). The traversed path through the decision tree.
             1. `question` (REQUIRED, string). The question id of the question.
             2. `answer` (REQUIRED, enum[string]). The answer to the question. The only valid values are `yes` or `no`.
-
-9. `labels` (OPTIONAL, list). This field allows to store meta information about a system. There can be multiple labels.
+9. `requirements` (OPTIONAL, list). To store the applicable requirements.
+        1. `urn` (REQUIRED, string). The URN of the requirement (from Algoritmekader).
+        2. `state` (REQUIRED, string). The state of the requirement.
+        3. `version` (OPTIONAL, string). The version of the Algoritmekader.
+10. `measures` (OPTIONAL, list). To store the applicable measures.
+        1. `urn` (REQUIRED, string). The URN of the measure (from Algoritmekader).
+        2. `state` (REQUIRED, string).
+        3. `value` (REQUIRED, string). Description on how the measure is implemented.
+        4. `version` (OPTIONAL, string). The version of the Algoritmekader.
+11. `labels` (OPTIONAL, list). This field allows to store meta information about a system. There can be multiple labels.
    For each label the following fields are present.
 
     1. `name` (OPTIONAL, string). Name of the label.
     2. `value` (OPTIONAL, string). Value of the label.
 
-10. `status` (OPTIONAL, string). The status of the system. For example the status can be "production".
-11. `begin_date` (OPTIONAL, string). The first date the system was used. Date should be given in
+12. `status` (OPTIONAL, string). The status of the system. For example the status can be "production".
+13. `begin_date` (OPTIONAL, string). The first date the system was used. Date should be given in
     [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `YYYY-MM-DD`.
-12. `end_date` (OPTIONAL, string). The last date the system was used. Date should be given in
+14. `end_date` (OPTIONAL, string). The last date the system was used. Date should be given in
     [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `YYYY-MM-DD`.
+15. `goal_and_impact` (OPTIONAL, string). The purpose of the system and the impact it has on citizens and companies.
+16. `considerations` (OPTIONAL, string). The pro's and con's of using the system.
+17. `risk_management` (OPTIONAL, string). Description of the risks associated with the system.
+18. `human_intervention` (OPTIONAL, string). A description to want extend there is human involvement in the system.
+19. `legal_base` (OPTIONAL, list). If there exists a legal base for the process the system is embedded in, this field
+    can be filled in with the relevant laws. There can be multiple legal bases. For each legal base the following fields
+    are present.
 
-13. `models` (OPTIONAL, list[ModelCard]). A list of model cards (as defined below) or `!include`s of a YAML file
+    1. `name` (OPTIONAL, string). Name of the law.
+    2. `link` (OPTIONAL, string). URI pointing towards the contents of the law.
+
+20. `used_data` (OPTIONAL, string). An overview of the data that is used in the system.
+21. `technical_design` (OPTIONAL, string). Description on how the system works.
+22. `external_providers` (OPTIONAL, list). If relevant, these fields allow to store information on external providers.
+    There can be multiple external providers.
+
+    1. `name` (OPTIONAL, string). Name of the external provider.
+    2. `version` (OPTIONAL, string). Version of the external provider reflecting its relation to previous versions.
+
+23. `references` (OPTIONAL, list[string]). Additional reference URI's that point information about the system and are
+    relevant.
+24. `interaction_details` (OPTIONAL, list[string]). Explain how the AI system interacts with hardware or software,
+    including other AI systems, or how the AI system can be used to interact with hardware or software.
+25. `version_requirements` (OPTIONAL, list[string]). Describe the versions of the relevant software or firmware, and any
+    requirements related to version updates.
+26. `deployment_variants` (OPTIONAL, list[string]). Description of all the forms in which the AI system is placed on the
+    market or put into service, such as software packages embedded into hardware, downloads, or APIs.
+27. `hardware_requirements` (OPTIONAL, list[string]). Provide a description of the hardware on which the AI system must
+    be run.
+28. `product_markings` (OPTIONAL, list[string]). If the AI system is a component of products, photos, or illustrations,
+    describe the external features, markings, and internal layout of those products.
+29. `user_interface` (OPTIONAL, list). Provide information on the user interface provided to the user responsible for
+    its operation.
+
+    1. `description` (OPTIONAL, string). A description of the provided user interface.
+    2. `link` (OPTIONAL, string). A link to the user interface can be included.
+    3. `snapshot` (OPTIONAL, string). A snapshot/screenshot of the user interface can be included with the use of a
+        hyperlink.
+
+30. `models` (OPTIONAL, list[ModelCard]). A list of model cards (as defined below) or `!include`s of a YAML file
     containing a model card. This model card can for example be a model card described in the next section or a model
     card from Hugging Face. There can be multiple model cards, meaning multiple models are used.
 
-14. `tasks` (OPTIONAL, list[TaskCard]). A list of task cards (as defined below) or `!include`s of a
-    YAML file containing a task card. This task card is an task card described in the next section.
-    There can be multiple task cards, meaning multiple task were performed.
+31. `assessments` (OPTIONAL, list[AssessmentCard]). A list of assessment cards (as defined below) or `!include`s of a
+    YAML file containing a assessment card. This assessment card is an assessment card described in the next section.
+    There can be multiple assessment cards, meaning multiple assessment were performed.
 
 ### `model_card`
 
@@ -291,11 +324,12 @@ A `model_card` contains the following information.
                         1. `x_value` (REQUIRED, float). The $x$-value of the graph.
                         2. `y_value` (REQUIRED, float). The $y$-value of the graph.
 
-### `task_card`
+### `assessment_card`
 
-An `task_card` contains the following information.
+An `assessment_card` contains the following information.
 
-1. `provenance` (OPTIONAL). This field can capture the context of the contents of this Task Card.
+1. `provenance` (OPTIONAL). In case this Assessment Card is generated from another source file, this field can capture
+   the historical context of the contents of this Assessment Card.
 
     1. `git_commit_hash` (OPTIONAL, string). Git commit hash of the commit which contains the transformation file used
        to create this card.
@@ -303,27 +337,25 @@ An `task_card` contains the following information.
        Timestamp should be given, preferably in UTC (represented as `Z`), in
        [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `2024-04-16T16:48:14Z`.
     3. `uri` (OPTIONAL, string). URI to the tool that was used to perform the transformations.
-    4. `description` (OPTIONAL, string). The description how the task is performed. 
-    5. `document` (OPTIONAL, string). Uploaded document. 
-    6. `URI` (OPTIONAL, string). Linked URI. 
-    7. `authors` (OPTIONAL, list). 
-        1. `name` (OPTIONAL, string). Name of person that initiated the transformations.
-        2. `function` (OPTIONAL, string). Function of the person that initiated the transformation (e.g. 'accountable'). 
-2. `name` (REQUIRED, string). The name of the task.
-3. `urn` (OPTIONAL, string). A Uniform Resource Name (URN) of the task in the task registry.
-4. `date` (REQUIRED, string). The date at which the task is completed. Date should be given in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `YYYY-MM-DD`.
-5. `lifecycle` (OPTIONAL, string). The lifecycle in which the task is completed. 
-6. `links` (OPTIONAL, list). List of linked tasks or systemcard fields.  
+    4. `author` (OPTIONAL, string). Name of person that initiated the transformations.
 
-    1. `name` (OPTIONAL, string). The name of the link. 
-    2. `urn` (REQUIRED, string). The urn to the link. 
-    3. `relation` (OPTIONAL, string). The relation between the links e.g. 'partly overlap'. 
-7. `contents` (REQUIRED, list). List of items in content.
+2. `name` (REQUIRED, string). The name of the assessment.
+3. `urn` (OPTIONAL, string). A Uniform Resource Name (URN) of the instrument in the task registry.
+4. `date` (REQUIRED, string). The date at which the assessment is completed. Date should be given in
+   [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `YYYY-MM-DD`.
+5. `contents` (REQUIRED, list). There can be multiple items in contents. For each item the following fields are present:
 
-    1. `description` (REQUIRED, string). A question.
-    2. `document` (OPTIONAL, string). A Uniform Resource Name (URN) of the corresponding task in the task registry.
-    3. `URI` (REQUIRED, string). An URI to a document. 
+    1. `question` (REQUIRED, string). A question.
+    2. `urn` (OPTIONAL, string). A Uniform Resource Name (URN) of the corresponding task in the task registry.
+    3. `answer` (REQUIRED, string). An answer.
     4. `remarks` (OPTIONAL, string). A field to put relevant discussion remarks in.
+    5. `authors` (OPTIONAL, list). There can be multiple names. For each name the following field is present.
+
+        1. `name` (OPTIONAL, string). The name of the author of the question.
+
+    6. `timestamp` (OPTIONAL, string). A timestamp of the date, time and timezone of the answer. Timestamp should be
+        given, preferably in UTC (represented as `Z`), in
+        [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, i.e. `2024-04-16T16:48:14Z`.
 
 ## Example
 
@@ -408,8 +440,8 @@ user_interface:
 models:
   - !include {model_card_uri}
 
-tasks:
-  - !include {task_card_uri}
+assessments:
+  - !include {assessment_card_uri}
 ```
 
 ### Model Card
@@ -489,40 +521,33 @@ model-index:
                       y_value: {y_value}
 ```
 
-### Task Card
+### Assessment Card
 
 ```yaml
 provenance:
   git_commit_hash: {git_commit_hash}
   timestamp: {modification_timestamp}
   uri: {modification_uri}
-  description: {description}
-  document: {document_path}
-  URI: {URI_path}
-  author: 
-  - name: {modificator_name}
-    function: {modificator_function}
-name: {task_name}
+  author: {modification_author}
+name: {assessment_name}
 urn: {urn}
-date: {task_date}
-lifecycle: {lifecycle}
-links:
-    - name: {link_name}
-      urn: {link_urn}
-      relation: {relation_type}
+date: {assessment_date}
 contents:
-  - description: {description_text}
-    document: {document_path}
-    URI: {URI_path}
-    remarks: {remark_text}
+  - question: {question_text}
+    urn: {urn}
+    answer: {answer_text}
+    remarks: {remarks_text}
+    authors:
+      - name: {author_name}
+    timestamp: {timestamp}
 ```
 
 ## Schema
 
-JSON schemas of the system card, model card and task card can be found on [Github](https://github.com/MinBZK/ai-validation/tree/main/docs/projects/amt/reporting-standard/schemas).
+JSON schemas of the system card, model card and assessment card can be found on [Github](https://github.com/MinBZK/ai-validation/tree/main/docs/projects/amt/reporting-standard/schemas).
 
 ## Changelog
-- 0.1a12: restructure systemcard to accomodate for tasks instead of assessments 
+
 - 0.1a11: adds requirements and measures
 - 0.1a10: adds ai act profile field to system card
 - 0.1a9: adds name to model card

--- a/docs/projects/amt/reporting-standard/latest.md
+++ b/docs/projects/amt/reporting-standard/latest.md
@@ -1,4 +1,4 @@
-# :label: 0.1a11 (Latest)
+# :label: 0.1a12 (Latest)
 
 This document describes the Algorithm Management Toolkit (AMT) Reporting Standard.
 
@@ -74,15 +74,15 @@ A `system_card` contains the following information.
 
 3. `name` (OPTIONAL, string). Name used to describe the system.
 
-4. `selected_tasks` (OPTIONAL, list). List of tasks from the [task registry](https://github.com/MinBZK/task-registry) that are selected to be performed categorized in requirements, measures and tools. 
+4. `selected_tasks` (OPTIONAL, list). List of tasks from the [task registry](https://github.com/MinBZK/task-registry) that are selected to be performed. 
     1. `requirements`(OPTIONAL, list). List of selected requirements. 
         1. `urn` (OPTIONAL, string). URN of the requirement.
         2. `version` (OPTIONAL, string). Version of the task registry. 
     2. `measures` (OPTIONAL, list). List of selected measures. 
-        1. `urn` (OPTIONAL, string). URN of the measures selected.
+        1. `urn` (OPTIONAL, string). URN of the measure.
         2. `version` (OPTIONAL, string). Version of the task registry. 
     3. `tools`(OPTIONAL, list). List of selected tools. 
-        1. `urn` (OPTIONAL, string). URN of the tools selected.
+        1. `urn` (OPTIONAL, string). URN of the tool.
         2. `version` (OPTIONAL, string). Version of the task registry.
 
 5. `upl` (OPTIONAL, string). If this algorithm is part of a product offered by the Dutch Government,
@@ -126,6 +126,8 @@ A `system_card` contains the following information.
         Options are `["transparantieverplichtingen", "geen transparantieverplichtingen"]`.
         6. `role` (OPTIONAL, enum[string]). The organization’s role in relation to the system.
         Options are `["aanbieder", "gebruiksverantwoordelijke", "aanbieder + gebruiksverantwoordelijke"]`
+        7. `conformity_assessment_body` (OPTIONAL, enum[string]). Whether the system should have a conformityassessment performed by a third party.
+        Options are `["beoordeling door derde partij"]`
     3. `decision_tree` (OPTIONAL). This field is REQUIRED if the above fields are retrieved by traversing the decision tree.
 
         1. `version` (REQUIRED, string). The version of the decision tree.
@@ -337,10 +339,16 @@ provenance:
   uri: {modification_uri}
   author: {modification_author}
 name: {system_name}
-instruments:
-  - urn: {instrument_urn}
-    version: {instrument_version}
-    required: {instrument_required}
+selected_tasks:
+  - requirements: 
+    - urn: {requirement_urn}
+      version: {version_task_registry}
+  - measures: 
+    - urn: {measure_urn}
+      version: {version_task_registry}
+  - tools: 
+    - urn: {tool_urn}
+      version: {version_task_registry}
 upl: {upl_uri}
 owners:
   - oin: {oin}
@@ -350,60 +358,31 @@ owners:
     role: {owner_role}
 description: {system_description}
 ai_act_profile:
-    type: {system_type}
-    open_source: {open_source}
-    publication_category: {publication_category}
-    systemic_risk: {systemic_risk}
-    transparency_obligations: {transparency_obligations}
-    role: {role}
+    provenance: 
+        git_commit_hash: {git_commit_hash}
+        timestamp: {modification_timestamp}
+        uri: {modification_uri}
+        author: {modification_author}
+    labels: 
+      - type: {system_type}
+        open_source: {open_source}
+        publication_category: {publication_category}
+        systemic_risk: {systemic_risk}
+        transparency_obligations: {transparency_obligations}
+        role: {role}
+        conformity_assessment_body: {conformity_assessment_body}
     decision_tree:
         version: {decision_tree_version}
         path:
          - question: {question_id}
            answer: {answer}
-requirements:
-    urn: {urn}
-    state: {state}
-    version: {version}
-measures:
-    urn: {urn}
-    state: {state}
-    value: {value}
-    version: {version}
 labels:
   - name: {label_name}
     value: {label_value}
 status: {system_status}
 begin_date: {system_begin_date}
 end_date: {system_end_date}
-goal_and_impact: {system_goal_and_impact}
-considerations: {system_considerations}
-risk_management: {system_risk_management}
-human_intervention: {system_human_intervention}
-legal_base:
-  - name: {law_name}
-    link: {law_uri}
-used_data: {system_used_data}
-technical_design: {technical_design}
-external_providers:
-  - name: {name_external_provider}
-    version: {version_external_provider}
-references:
-  - {reference_uri}
-interaction_details:
-  - {system_interaction_details}
-version_requirements:
-  - {system_version_requirements}
-deployment_variants:
-  - {system_deployment_variants}
-hardware_requirements:
-  - {system_hardware_requirements}
-product_markings:
-  - {system_product_markings}
-user_interface:
-  - description: {system_user_interface}
-    link: {system_user_interface_uri}
-    snapshot: {system_user_interface_snapshot_uri}
+
 
 models:
   - !include {model_card_uri}


### PR DESCRIPTION
# Description

In this PR, we propose the following systemcard structure. With this proposal we move the use and goal of the systemcard from being an administration to using it as a reference documentation. 


In this proposed structure the major changes are: 
- List of tasks (requirements, measures and tools) to be done is included in the root of the systemcard. The actual performance and result of a task is split out and stored in a task card. 
- We store the outcomes of the task and the audittrail in the task card once the task is done. 
- The fields in the systemcard on humen_intervention and goal_and_impact etc. are removed as they are answered by performing the tasks. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilizes.

## Developer Certificate of Origin

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
